### PR TITLE
fix useCubes dev helper for networked use

### DIFF
--- a/src/view/ThreeView.js
+++ b/src/view/ThreeView.js
@@ -186,7 +186,6 @@ ThreeView.prototype = {
     },
 
     onMeshLoaded: function(threeParent, meshComp, geometry, material) {
-        debugger;
         if (!useCubes && geometry === undefined) {
             console.log("mesh load failed");
             return;


### PR DESCRIPTION
is hackish but works, better fix coming later when the logic with empty asset refs coming to mesh attrs first etc. is handled better, also changing asset refs is to be tested etc.
