### PR TITLE
port the most basic suzanne xml3d example to dev2. sceneparser was already ported earlier

### DIFF
--- a/examples/xml3d/example-suzanne.html
+++ b/examples/xml3d/example-suzanne.html
@@ -1,57 +1,24 @@
 <!doctype html>
 <html lang="en">
 <head>
-    <title>xml3d parser example scene</title>
+    <title>XML3D Parser Example</title>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, user-scalable=no, minimum-scale=1.0, maximum-scale=1.0">
 </head>
+<style type="text/css">
+    html {
+        margin: 0px; padding: 0px; overflow: hidden;
+    }
+    body {
+        position: absolute; padding: 0px; margin: 0px; width: 100%; height: 100%; overflow: hidden;
+    }
+    #webtundra-container-custom {
+        position: absolute; background-color: black; width: 100%; height: 100%;
+    }
+    </style>
 <body>
 
-<!-- EC -->
-<script src="../../src/util/Signals.js"></script>
-<script src="../../src/util/CompoundSignal.js"></script>
-<script src="../../src/network/DataSerializer.js"></script>
-<script src="../../src/network/DataDeserializer.js"></script>
-<script src="../../src/network/WebSocketClient.js"></script>
-<script src="../../src/network/SyncManager.js"></script>
-<script src="../../src/scene/UniqueIdGenerator.js"></script>
-<script src="../../src/scene/Attribute.js"></script>
-<script src="../../src/scene/Component.js"></script>
-<script src="../../src/scene/Entity.js"></script>
-<script src="../../src/scene/Scene.js"></script>
-<script src="../../src/scene/EC_DynamicComponent.js"></script>
-<script src="../../src/scene/EC_EnvironmentLight.js"></script>
-<script src="../../src/scene/EC_Mesh.js"></script>
-<script src="../../src/scene/EC_Name.js"></script>
-<script src="../../src/scene/EC_Placeable.js"></script>
-<script src="../../src/scene/EC_RigidBody.js"></script>
-<script src="../../src/scene/EC_Script.js"></script>
-<script src="../../src/scene/EC_Sky.js"></script>
-<script src="../../src/scene/EC_Light.js"></script>
-<script src="../../src/scene/EC_Camera.js"></script>
-<script src="../../src/scene/EC_Sound.js"></script>
-
-<script src="../../src/view/js/Three.js"></script>
-<script src="../../src/view/js/Detector.js"></script>
-<script src="../../src/view/js/Stats.js"></script>
-<script src="../../src/view/js/THREEx.KeyboardState.js"></script>
-<script src="../../src/view/js/THREEx.FullScreen.js"></script>
-<script src="../../src/view/js/THREEx.WindowResize.js"></script>
-
-<script src="../../src/scene/SceneParser.js"></script>
-<script src="../../src/app.js"></script>
-<script src="../../src/WebTundraModel.js"></script>
-<script src="../../src/view/ThreeView.js"></script>
-<script src="../../src/view/EC_PlaceableView.js"></script>
-<script src="../../src/view/EC_AnimationControllerView.js"></script>
-<script src="../../src/scene/Bone.js"></script>
-<script src="../../src/view/BoneView.js"></script>
-<script src="../../src/view/js/EditorControls.js"></script>
-<script src="loadxml3d.js"></script>
-
-<!-- ------------------------------------------------------------ -->
-
-<div id="ThreeJS" style="z-index: 1; position: absolute; left:0px; top:0px"></div>
+<div id="webtundra-container-custom"></div>
 
         <xml3d id="MyXml3d" activeView="#defaultView" class="xml3d"
                style="width: 600px; height: 400px;" >
@@ -84,9 +51,8 @@
                 <light shader="#ls_Spot"></light>
             </group>
         </xml3d>
-  
-<script>
-    loadxml3d();
-</script>
+
+<!-- require.js entry point -->
+<script data-main="loadxml3d.js" src="../../src/lib/require.min.js"></script>
 </body>
 </html>


### PR DESCRIPTION
this is just the entry point for the standalone example, following how physics2 was created as a new entrypoint previously. notably this is the first entrypoint which works in dev2 without login ui or server connection.

NOTE: free cam does not work here yet, to be improved (possibly the cam from xml3d decl is activated but that one doesn't have controls)
