### PR TITLE
Sceneparser freecam

### DIFF
--- a/examples/xml3d/loadxml3d.js
+++ b/examples/xml3d/loadxml3d.js
@@ -66,13 +66,22 @@ require([
     var freecamera = null;
 //    var instructions = null;
 
-/*
-    // Connected to server
-    client.onConnected(null, function() {
-        // Setup initial camera position
-        if (freecamera && freecamera.cameraEntity)
-            freecamera.cameraEntity.placeable.setPosition(0, 8.50, 28.50);
+    // Start freecam app - the xml3d parser will position current active cam by <view> declaration
+    $.getScript("../../src/application/freecamera.js")
+        .done(function( script, textStatus ) {
+            freecamera = new FreeCameraApplication();
+            freecamera.createCamera();
+            var sceneParserPlugin = TundraSDK.plugin("SceneParserPlugin");
+            var xml3dParser = sceneParserPlugin.newXML3DParser(client.scene);
+            $(document).ready(function() {
+                xml3dParser.parseDocXml3D(document);
+            });
+        })
+        .fail(function(jqxhr, settings, exception) {
+            console.error("Failed to load FreeCamera application:", exception);
+        });
 
+/*
         instructions = $("<div/>", { 
             text : "Click on the top sphere to start the physics simulation",
             css : {
@@ -93,22 +102,4 @@ require([
         var dirLight = new THREE.DirectionalLight();
         client.renderer.scene.add(dirLight);
 //    });
-
-    var sceneParserPlugin = TundraSDK.plugin("SceneParserPlugin");
-    var xml3dParser = sceneParserPlugin.newXML3DParser(client.scene);
-    $(document).ready(function() {
-        xml3dParser.parseDocXml3D(document);
-
-        // Start freecam app - after xml3d parsing because that actually creates the camera for us (from the <view> declaration)
-        $.getScript("../../src/application/freecamera.js")
-            .done(function( script, textStatus ) {
-                freecamera = new FreeCameraApplication();
-                freecamera.cameraEntity = TundraSDK.framework.renderer.activeCamera().parentEntity;
-                freecamera.createCamera(); //doesn't actually create as we just created it but hooks event listeners etc
-            })
-            .fail(function(jqxhr, settings, exception) {
-                console.error("Failed to load FreeCamera application:", exception);
-            }
-            );
-    });
 });

--- a/src/plugins/scene-parser/SceneParser.js
+++ b/src/plugins/scene-parser/SceneParser.js
@@ -271,25 +271,31 @@ var SceneParser = Class.$extend(
             viewPosition = xview.getAttribute("position");
             viewOrientation = xview.getAttribute("orientation");
 
-            var entity = this.scene.createLocalEntity(["Name", "Placeable", "Camera"]);
-            entity.name = viewId || "XML3D View";
-
-            // Placeable
-            var px = entity.placeable.transform;
-            if (viewPosition)
-                wtSplitToXyz(viewPosition, px.pos);
-            if (viewOrientation)
-                wtSplitAxisAngleToEulerXyz(viewOrientation, px.rot);
-            entity.placeable.transform = px; // trigger signal
-
             // Camera
-            /// @todo Read and set aspect ratio to camera from <view>
-            //entity.camera.aspectRatio = ??;
+            var actcam = TundraSDK.framework.renderer.activeCamera();
+            var cament;
+            if (!actcam) {
+                cament = this.scene.createLocalEntity(["Name", "Placeable", "Camera"]);
+                cament.name = viewId || "XML3D View";
+                this.log.debug("    Created", cament.camera.toString());
+                cament.camera.setActive();
+                this.log.debug("    Activated camera in", cament.toString());
+            } else {
+                cament = actcam.parentEntity;
+                this.log.debug("    Configuring pre-existing active camera", cament.camera.toString());
+            }
+            // Placeable
+            var px = cament.placeable.transform;
+            if (viewPosition) {
+                wtSplitToXyz(viewPosition, px.pos);
+            }
+            if (viewOrientation) {
+                wtSplitAxisAngleToEulerXyz(viewOrientation, px.rot);
+            }
+            cament.placeable.transform = px; // trigger signal
 
-            this.log.debug("    Created", entity.camera.toString());
-            entity.camera.setActive();
-            this.log.debug("    Activated camera in", entity.toString());
-            
+            /// @todo Read and set aspect ratio to camera from <view>
+            //cament.camera.aspectRatio = ??;
         }
     }
 });


### PR DESCRIPTION
make freecam work with sceneparser by following the pattern from native tundra: 

free cam app is created first, &lt;view&gt; declaration just positions it (or whatever the active camera is) in SceneParser. 

if there is no pre-existing active camera, SceneParser creates own (with no controls) like before, which is also the correct xml3d behaviour.
