### PR TITLE
Initial rigidbody message handling + IM observer position

### DIFF
--- a/src/core/data/DataDeserializer.js
+++ b/src/core/data/DataDeserializer.js
@@ -570,9 +570,7 @@ var DataDeserializer = Class.$extend(
         var val3 = val % max3;
         val = Math.floor(val / max3);
         var val2 = val % max2;
-        val = Math.floor(val / max2);
-        var val1 = val % max1;
-        val = Math.floor(val / max1);
+        var val1 = Math.floor(val / max2);
         return [val1, val2, val3, val4, val5];
     },
 
@@ -662,8 +660,8 @@ var DataDeserializer = Class.$extend(
     readNormalizedVector3D : function(numBitsYaw, numBitsPitch)
     {
         var ret = {};
-        var azimuth = this.readBits(-Math.PI, Math.PI, numBitsYaw);
-        var inclination = this.readBits(-Math.PI/2, Math.PI/2, numBitsPitch);
+        var azimuth = this.readQuantizedFloat(-Math.PI, Math.PI, numBitsYaw);
+        var inclination = this.readQuantizedFloat(-Math.PI/2, Math.PI/2, numBitsPitch);
         var cx = Math.cos(inclination);
         ret.x = cx * Math.sin(azimuth);
         ret.y = -Math.sin(inclination);
@@ -679,15 +677,15 @@ var DataDeserializer = Class.$extend(
         @param {Number} magnitudeDecimalBits Number of bits for magnitude decimal part
         @return {Object} Object with x, y, z fields, representing the 3D vector
      */
-    readVector3D : function(numBitsYaw, numBitsPitch, magnitudeIntegerBits, magnitudeDecimalBits, directionBits)
+    readVector3D : function(numBitsYaw, numBitsPitch, magnitudeIntegerBits, magnitudeDecimalBits)
     {
         var ret = {};
         var fp = this.readBits(magnitudeIntegerBits + magnitudeDecimalBits);
         if (fp != 0)
         {
             var len = fp / (1 << magnitudeDecimalBits);
-            var azimuth = this.readBits(-Math.PI, Math.PI, numBitsYaw);
-            var inclination = this.readBits(-Math.PI/2, Math.PI/2, numBitsPitch);
+            var azimuth = this.readQuantizedFloat(-Math.PI, Math.PI, numBitsYaw);
+            var inclination = this.readQuantizedFloat(-Math.PI/2, Math.PI/2, numBitsPitch);
             var cx = Math.cos(inclination);
             ret.x = cx * Math.sin(azimuth) * len;
             ret.y = -Math.sin(inclination) * len;

--- a/src/core/data/DataDeserializer.js
+++ b/src/core/data/DataDeserializer.js
@@ -4,29 +4,61 @@ define([
         "lib/bitarray"
     ], function(Class, BitArray) {
 
-/**
-    Utility class to parse JavaScript Arraybuffer data.
-
-    @class DataDeserializer
-    @constructor
-    @param {ArrayBuffer} buffer Source data buffer.
-    @param {Number} pos Data position to proceed reading from.
-*/
 var DataDeserializer = Class.$extend(
+/** @lends DataDeserializer.prototype */
 {
+    /**
+        Utility class to parse JavaScript ArrayBuffer data.
+
+        @constructs
+        @param {ArrayBuffer} buffer Source data buffer.
+        @param {Number} [pos=0] Data position to proceed reading from.
+        @param {Number} [length] Custom data length, read from buffer if not defined.
+    */
     __init__ : function(buffer, pos, length)
     {
+        /**
+            @var {DataView} data
+            @memberof DataDeserializer.prototype
+        */
+        /**
+            The current element we're reading from the data buffer.
+            @var {Number}
+        */
+        this.bytePos = 0;
+        /**
+            The current bit index of the byte we're reading, [0, 7].
+            @var {Number}
+        */
+        this.bitPos = 0;
+
         if (buffer !== undefined)
             this.setBuffer(buffer, pos, length);
+
+        // Backwards compatibility for .pos > this.bytesRead() > this.bytePos
+        // Disabled due to this causing slowdown on Firefox when using DataDeserializer 
+        // even if the pos property is not accessed
+        /*
+        Object.defineProperties(this, {
+            pos : {
+                get : function () { return this.bytesRead(); }
+            }
+        });
+        */
     },
 
     __classvars__ :
     {
+        // For reading non-aligned floats
+        floatReadDataView  : new DataView(new ArrayBuffer(4)),
+        // For reading non-aligned doubles
+        doubleReadDataView : new DataView(new ArrayBuffer(8)),
+
         /**
             Reads a byte from bits.
+
             @static
-            @method readByteFromBits
-            @param {BitArray} bits Source bits. See {{#crossLink "DataDeserializer/readBits:method"}}readBits(){{/crossLink}}.
+            @param {BitArray} bits Source bits. See {@link DataDeserializer#readBits}.
             @param {Number} pos Position to start reading the byte.
             @return {Number} Read byte.
         */
@@ -42,92 +74,92 @@ var DataDeserializer = Class.$extend(
                     byte &= ~(1 << bi);
             }
             return byte;
-        },
-
-        /** Utility dataview for reading non-bit aligned float data */
-        floatReadData : new DataView(new ArrayBuffer(8))
+        }
     },
 
     /**
         Set new data source and position.
-        @method setBuffer
+
         @param {ArrayBuffer} buffer Source data buffer.
         @param {Number} pos Data position to proceed reading from.
     */
     setBuffer : function(buffer, pos, length)
     {
         // Firefox DataView does not correctly support length as 'undefined'
+        // TODO Seems fine on latest FF, this if-else could be removed?
         if (length === undefined)
             this.data = new DataView(buffer, pos);
         else
             this.data = new DataView(buffer, pos, length);
-        this.pos = 0;
+        this.bytePos = 0;
         this.bitPos = 0;
     },
 
     /**
         Read bytes as a new buffer.
-        @note Does not respect bit position
-        @method readUint8Array
+
         @param {Number} numBytes Number of bytes to read.
         @return {Uint8Array} Read buffer.
     */
     readUint8Array : function(numBytes)
     {
-        //var buffer = this.data.buffer.subarray(this.pos, numBytes);
-        var buffer = new Uint8Array(this.data.buffer, this.pos, numBytes);
-        this.pos += numBytes;
+        //var buffer = this.data.buffer.subarray(this.bytePos, numBytes);
+        var buffer = new Uint8Array(this.data.buffer, this.bytePos, numBytes);
+        this.bytePos += numBytes;
         return buffer;
     },
 
     /**
         Returns the currently read bytes.
-        @method readBytes
+
         @return {Number} Number of read bytes.
     */
-    readBytes : function()
+    bytesRead : function()
     {
-        return this.pos;
+        return this.bytePos;
     },
+
+    // TODO Remove, confusing name as all other readXXX() functions actually read data.
+    readBytes : function() { return this.bytesRead(); },
 
     /**
         Returns how many bytes are left.
-        @method bytesLeft
+
         @return {Number} Number of bytes left.
     */
     bytesLeft : function()
     {
-        return (this.data.byteLength - this.pos);
+        return this.bytePos >= this.data.byteLength ? 0 : this.data.byteLength - this.bytePos;
     },
-    
+
     /**
         Returns how many bits are left.
-        @method bitsLeft
-        @return {Number} Number of bits left.
+
+        @return {Number} - Number of bytes left.
     */
     bitsLeft : function()
     {
-        return (this.data.byteLength - this.pos) * 8 - this.bitPos;
+        return this.bytePos >= this.data.byteLength ? 0 : (this.data.byteLength - this.bytePos) * 8 - this.bitPos;
     },
 
     /**
         Skips bytes. Use negative numBytes to go backwards.
-        @method skipBytes
+
         @param {Number} numBytes Number of bytes to skip.
     */
     skipBytes : function(numBytes)
     {
-        this.pos += numBytes;
+        this.bytePos += numBytes;
     },
 
     /**
-        Reads a u8 and returns true if >0, otherwise false.
-        @method readBoolean
+        Reads a single byte and interprets it as a boolean.
+
         @return {Boolean} Read boolean.
     */
     readBoolean : function()
     {
-        return (this.readU8() > 0 ? true : false);
+        return (this.readU8() > 0);
     },
 
     // Make this work but don't document to encourage use.
@@ -137,51 +169,52 @@ var DataDeserializer = Class.$extend(
     },
 
     /**
-        Reads a single UTF8 code point aka char code in JavaScript.
+        Reads a single UTF-8 code point aka char code in JavaScript.
 
         Code adapted from https://github.com/realXtend/WebTundraNetworking/blob/master/src/DataDeserializer.js
-        @method readUtf8CharCode
+
         @return {Number} Char code of the character.
     */
     readUtf8CharCode : function()
     {
-        var char1 = this.readU8();
+        var char1, char2, char3, char4, char5;
+        char1 = this.readU8();
         if (char1 < 0x80)
         {
             return char1;
         }
         else if (char1 < 0xe0)
         {
-            var char2 = this.readU8();
+            char2 = this.readU8();
             return (char2 & 0x3f) | ((char1 & 0x1f) << 6);
         }
         else if (char1 < 0xf0)
         {
-            var char2 = this.readU8();
-            var char3 = this.readU8();
+            char2 = this.readU8();
+            char3 = this.readU8();
             return (char3 & 0x3f) | ((char2 & 0x3f) << 6) | ((char1 & 0xf) << 12);
         }
         else if (char1 < 0xf8)
         {
-            var char2 = this.readU8();
-            var char3 = this.readU8();
-            var char4 = this.readU8();
+            char2 = this.readU8();
+            char3 = this.readU8();
+            char4 = this.readU8();
             return (char4 & 0x3f) | ((char3 & 0x3f) << 6) | ((char2 & 0x3f) << 12) | ((char1 & 0x7) << 18);
         }
         else if (char1 < 0xfc) {
-            var char2 = this.readU8();
-            var char3 = this.readU8();
-            var char4 = this.readU8();
-            var char5 = this.readU8();
+            char2 = this.readU8();
+            char3 = this.readU8();
+            char4 = this.readU8();
+            char5 = this.readU8();
             return (char5 & 0x3f) | ((char4 & 0x3f) << 6) | ((char3 & 0x3f) << 12) | ((char2 & 0x3f) << 18) | ((char1 & 0x3) << 24);
         }
         else
         {
-            var char2 = this.readU8();
-            var char3 = this.readU8();
-            var char4 = this.readU8();
-            var char5 = this.readU8();
-            var char6 = this.readU8();
+            char2 = this.readU8();
+            char3 = this.readU8();
+            char4 = this.readU8();
+            char5 = this.readU8();
+            char6 = this.readU8();
             return (char6 & 0x3f) | ((char5 & 0x3f) << 6) | ((char4 & 0x3f) << 12) | ((char3 & 0x3f) << 18) | ((char2 & 0x3f) << 24) | ((char1 & 0x1) << 30);
         }
     },
@@ -192,7 +225,7 @@ var DataDeserializer = Class.$extend(
 
         This function is useful for reading null or newline terminated strings.
         Pass delimStr as '\n' or delimCharCode as 10 for null terminated string.
-        @method readStringUntil
+
         @param {String} delimStr String delimiter.
         @param {Number} delimCharCode Charcode delimiter.
         @return {String} Read string.
@@ -215,7 +248,7 @@ var DataDeserializer = Class.$extend(
 
     /**
         Reads string with length.
-        @method readString
+
         @param {Number} length String length.
         @return {String} Read string.
     */
@@ -227,12 +260,15 @@ var DataDeserializer = Class.$extend(
         var str = "";
         if (length > 0)
         {
-            var endPos = this.pos + length;
-            while (this.pos < endPos)
+            var endPos = this.bytePos + length;
+            if (utf8)
             {
-                if (utf8)
-                    str += String.fromCharCode(this.readUtf8CharCode(endPos - this.pos));
-                else
+                while(this.bytePos < endPos)
+                    str += String.fromCharCode(this.readUtf8CharCode(endPos - this.bytePos));
+            }
+            else
+            {
+                while(this.bytePos < endPos)
                     str += String.fromCharCode(this.readU8());
             }
         }
@@ -241,7 +277,7 @@ var DataDeserializer = Class.$extend(
 
     /**
         Reads u8 length string.
-        @method readStringU8
+
         @return {String} Read string.
     */
     readStringU8 : function(utf8)
@@ -251,7 +287,7 @@ var DataDeserializer = Class.$extend(
 
     /**
         Reads u16 length string.
-        @method readStringU16
+
         @return {String} Read string.
     */
     readStringU16 : function(utf8)
@@ -261,7 +297,7 @@ var DataDeserializer = Class.$extend(
 
     /**
         Reads u32 length string.
-        @method readStringU32
+
         @return {String} Read string.
     */
     readStringU32 : function(utf8)
@@ -271,16 +307,16 @@ var DataDeserializer = Class.$extend(
 
     /**
         Reads s8.
-        @method readS8
-        @return {byte} s8
+
+        @return {Number} s8
     */
     readS8 : function()
     {
-        if (this.bitPos == 0)
+        if (this.bitPos === 0)
         {
-            var s8 = this.data.getInt8(this.pos);
-            this.pos += 1;
-            return s8;
+            var ret = this.data.getInt8(this.bytePos);
+            this.bytePos += 1;
+            return ret;
         }
         else
         {
@@ -293,35 +329,33 @@ var DataDeserializer = Class.$extend(
 
     /**
         Reads u8.
-        @method readU8
-        @return {unsigned byte} u8
+
+        @return {Number} u8
     */
     readU8 : function()
     {
-        if (this.bitPos == 0)
+        if (this.bitPos === 0)
         {
-            var u8 = this.data.getUint8(this.pos);
-            this.pos += 1;
-            return u8;
+            var ret = this.data.getUint8(this.bytePos);
+            this.bytePos += 1;
+            return ret;
         }
         else
-        {
             return this.readBits(8);
-        }
     },
 
     /**
         Reads s16.
-        @method readS16
-        @return {short} s16
+
+        @return {Number} s16
     */
     readS16 : function()
     {
-        if (this.bitPos == 0)
+        if (this.bitPos === 0)
         {
-            var s16 = this.data.getInt16(this.pos, true);
-            this.pos += 2;
-            return s16;
+            var ret = this.data.getInt16(this.bytePos);
+            this.bytePos += 2;
+            return ret;
         }
         else
         {
@@ -334,35 +368,33 @@ var DataDeserializer = Class.$extend(
 
     /**
         Reads u16.
-        @method readU16
-        @return {unsigned short} u16
+
+        @return {Number} u16
     */
     readU16 : function()
     {
-        if (this.bitPos == 0)
+        if (this.bitPos === 0)
         {
-            var u16 = this.data.getUint16(this.pos, true);
-            this.pos += 2;
-            return u16;
+            var ret = this.data.getUint16(this.bytePos, true);
+            this.bytePos += 2;
+            return ret;
         }
         else
-        {
             return this.readBits(16);
-        }
     },
 
     /**
         Reads s32.
-        @method readS32
-        @return {long} s32
+
+        @return {Number} s32
     */
     readS32 : function()
     {
-        if (this.bitPos == 0)
+        if (this.bitPos === 0)
         {
-            var s32 = this.data.getInt32(this.pos, true);
-            this.pos += 4;
-            return s32;
+            var ret = this.data.getInt32(this.bytePos, true);
+            this.bytePos += 4;
+            return ret;
         }
         else
         {
@@ -375,68 +407,65 @@ var DataDeserializer = Class.$extend(
 
     /**
         Reads u32.
-        @method readU32
-        @return {unsigned long} u32
+
+        @return {Number} u32
     */
     readU32 : function()
     {
-        if (this.bitPos == 0)
+        if (this.bitPos === 0)
         {
-            var u32 = this.data.getUint32(this.pos, true);
-            this.pos += 4;
-            return u32;
+            var ret = this.data.getUint32(this.bytePos, true);
+            this.bytePos += 4;
+            return ret;
         }
         else
-        {
             return this.readBits(32);
-        }
     },
 
     /**
         Reads f32.
-        @method readFloat32
-        @return {float} f32
+
+        @return {Number} f32
     */
     readFloat32 : function()
     {
-        if (this.bitPos == 0)
+        if (this.bitPos === 0)
         {
-            var f32 = this.data.getFloat32(this.pos, true);
-            this.pos += 4;
-            return f32;
+            var ret = this.data.getFloat32(this.bytePos, true);
+            this.bytePos += 4;
+            return ret;
         }
         else
         {
-            this.$class.floatReadData.setUint32(0, this.readBits(32), true);
-            return this.$class.floatReadData.getFloat32(0, true);
+            DataDeserializer.floatReadDataView.setUint32(0, this.readBits(32), true);
+            return DataDeserializer.floatReadDataView.getFloat32(0, true);
         }
     },
 
     /**
         Reads f64.
-        @method readFloat64
-        @return {double} f64
+
+        @return {Number} f64
     */
     readFloat64 : function()
     {
-        if (this.bitPos == 0)
+        if (this.bitPos === 0)
         {
-            var f64 = this.data.getFloat64(this.pos, true);
-            this.pos += 8;
-            return f64;
+            var ret = this.data.getFloat64(this.bytePos, true);
+            this.bytePos += 8;
+            return ret;
         }
         else
         {
-            this.$class.floatReadData.setUint32(0, this.readBits(32), true);
-            this.$class.floatReadData.setUint32(4, this.readBits(32), true);
-            return this.$class.floatReadData.getFloat64(0, true);
+            DataDeserializer.doubleReadDataView.setUint32(0, this.readBits(32), true);
+            DataDeserializer.doubleReadDataView.setUint32(4, this.readBits(32), true);
+            return DataDeserializer.doubleReadDataView.getFloat64(0, true);
         }
-
     },
 
     /**
         Reads three f32 to a object { x : <f32>, y : <f32>, z : <f32> }.
-        @method readFloat32Vector3
+
         @return {Object}
     */
     readFloat32Vector3 : function()
@@ -450,7 +479,7 @@ var DataDeserializer = Class.$extend(
 
     /**
         Reads four f32 to a object { x : <f32>, y : <f32>, z : <f32>, w : <f32> }.
-        @method readFloat32Vector4
+
         @return {Object}
     */
     readFloat32Vector4 : function()
@@ -465,18 +494,18 @@ var DataDeserializer = Class.$extend(
 
     /**
         Reads VLE.
-        @method readVLE
+
         @return {Number} Read VLE value.
     */
     readVLE : function()
     {
         // Copied from https://github.com/realXtend/WebTundraNetworking/blob/master/src/DataDeserializer.js
         var low = this.readU8();
-        if ((low & 128) == 0)
+        if ((low & 128) === 0)
             return low;
         low = low & 127;
         var med = this.readU8();
-        if ((med & 128) == 0)
+        if ((med & 128) === 0)
             return low | (med << 7);
         med = med & 127;
         var high = this.readU16();
@@ -484,32 +513,42 @@ var DataDeserializer = Class.$extend(
     },
 
     /**
-        Reads a number of bits and returns an unsigned number value.
-        @method readBits
-        @param {Number} numBits Number of bits to read
-        @return {Number} Read unsigned value.
+        Reads a single bit.
+
+        @return {Number} Value of the bit.
     */
-    readBits : function(numBits)
+    readBit : function()
+    {
+        return this.readBits(1);
+    },
+
+    /**
+        Reads specified amount of bits.
+
+        @param {Number} bitCount How many bits to read.
+        @return {Number} Read bits as a Number.
+    */
+    readBits : function(bitCount)
     {
         var ret = 0;
         var shift = 0;
-        var currentByte = this.data.getUint8(this.pos);
+        var currentByte = this.data.getUint8(this.bytePos);
 
-        while (numBits > 0)
+        while (bitCount > 0)
         {
             if (currentByte & (1 << this.bitPos))
                 ret |= (1 << shift);
 
             shift++;
-            numBits--;
+            bitCount--;
             this.bitPos++;
 
             if (this.bitPos > 7)
             {
                 this.bitPos = 0;
-                this.pos++;
-                if (numBits > 0)
-                    currentByte = this.data.getUint8(this.pos);
+                this.bytePos++;
+                if (bitCount > 0)
+                    currentByte = this.data.getUint8(this.bytePos);
             }
         }
 
@@ -517,22 +556,12 @@ var DataDeserializer = Class.$extend(
     },
 
     /**
-        Read one bit.
-        @method readBit
-        @return {Number} Read bit value (0/1)
-    */
-    readBit : function()
-    {
-        return this.readBits(1);
-    },
-    
-    /**
-        Reads bytes as bits to a BitArray.
-        @method readBits
+        Reads bytes as bits.
+
         @param {Number} bytes How many bytes to read as bits.
         @return {BitArray} Read bits. See http://github.com/bramstein/bit-array
     */
-    readBitsToArray : function(bytes)
+    readBitArray : function(bytes)
     {
         var bitIndex = 0;
         var bits = new BitArray(bytes*8, 0);
@@ -548,157 +577,156 @@ var DataDeserializer = Class.$extend(
         }
         return bits;
     },
-    
-    /**
-        Reads 5 arithmetic encoded values.
-        @method readArithmeticEncoded
-        @param {Number} numBits How many bits to read
-        @param {Number} max1 Maximum value of first value
-        @param {Number} max2 Maximum value of second value
-        @param {Number} max3 Maximum value of third value
-        @param {Number} max4 Maximum value of fourth value
-        @param {Number} max5 Maximum value of fifth value
-        @return {Array} Values as array
-     */
-    readArithmeticEncoded : function(numBits, max1, max2, max3, max4, max5)
+
+    /** Input parameters ints.
+
+        @return {Number} Float */
+    readUnsignedFixedPoint : function(numIntegerBits, numDecimalBits)
     {
-        var val = this.readBits(numBits);
-        var val5 = val % max5;
-        val = Math.floor(val / max5);
-        var val4 = val % max4;
-        val = Math.floor(val / max4);
-        var val3 = val % max3;
-        val = Math.floor(val / max3);
-        var val2 = val % max2;
-        var val1 = Math.floor(val / max2);
-        return [val1, val2, val3, val4, val5];
+        var fp = this.readBits(numIntegerBits + numDecimalBits);
+        return fp / (1 << numDecimalBits);
     },
 
-    /** Reads a signed fixed point value.
-        @method readSignedFixedPoint
-        @param {Number} numIntegerBits Number of integer bits
-        @param {Number} numDecimalBits Number of decimal bits
-        @return {Number} Value
-     */
+    /** Input parameters ints.
+
+        @return {Number} Float */
     readSignedFixedPoint : function(numIntegerBits, numDecimalBits)
     {
+        // Reading a [0, 2k-1] range -> remap back to [-k, k-1] range.
         return this.readUnsignedFixedPoint(numIntegerBits, numDecimalBits) - (1 << (numIntegerBits-1));
     },
 
-    /** Reads an unsigned fixed point value.
-        @method readUnsignedFixedPoint
-        @param {Number} numIntegerBits Number of integer bits
-        @param {Number} numDecimalBits Number of decimal bits
-        @return {Number} Value
-     */
-    readUnsignedFixedPoint : function(numIntegerBits, numDecimalBits)
-    {
-        var val = this.readBits(numIntegerBits + numDecimalBits);
-        return val / (1 << numDecimalBits);
-    },
+    /** minRange and maxRange floats, numBits int
 
-    /** Reads a quantized float value.
-        @method readQuantizedFloat
-        @param {Number} minRange Minimum possible value
-        @param {Number} maxRange Maximum possible value
-        @param {Number} numBits Number of bits to read
-        @return {Number} Value
-     */
+        @return {Number} Float */
     readQuantizedFloat : function(minRange, maxRange, numBits)
     {
         var val = this.readBits(numBits);
-        return minRange + val * (maxRange - minRange) / ((1 << numBits) - 1);
+        return minRange + val * (maxRange-minRange) / ((1 << numBits) - 1);
     },
 
-    /** Reads a normalized 2D vector using the specified amount of bits (angle representation)
-        @method readNormalizedVector2D
-        @param {Number} numBits Number of bits to read
-        @return {Object} Object with x & y fields, representing the 2D vector
-     */
+    /** @return {Object} { x : <value>, y : <value> } */
     readNormalizedVector2D : function(numBits)
     {
-        var ret = {};
         var angle = this.readQuantizedFloat(-Math.PI, Math.PI, numBits);
-        ret.x = Math.cos(angle);
-        ret.y = Math.sin(angle);
-        return ret;
+        return { x: Math.cos(angle), y : Math.sin(angle) };
     },
 
-    /** Reads a 2D vector using the specified amount of bits.
-        @method readVector2D
-        @param {Number} magnitudeIntegerBits Number of bits for magnitude integer part
-        @param {Number} magnitudeDecimalBits Number of bits for magnitude decimal part
-        @param {Number} directionBits Number of bits for direction
-        @return {Object} Object with x & y fields, representing the 2D vector
-     */
+    /**  All input parameters int.
+
+        @return {Object} { x : <value>, y : <value> } */
     readVector2D : function(magnitudeIntegerBits, magnitudeDecimalBits, directionBits)
     {
-        var ret = {};
+        // this.read the length in unsigned fixed point format.
+        // The following line is effectively the same as calling this.readUnsignedFixedPoint, but manually perform it
+        // to be precisely able to examine whether the length is zero.
         var fp = this.readBits(magnitudeIntegerBits + magnitudeDecimalBits);
-        if (fp != 0)
+        if (fp !== 0) // If length is non-zero, the stream also contains the direction.
         {
-            var len = fp / (1 << magnitudeDecimalBits);
+            var length = fp / (1 << magnitudeDecimalBits);
+            // Read the direction in the stream.
             var angle = this.readQuantizedFloat(-Math.PI, Math.PI, directionBits);
-            ret.x = Math.cos(angle) * len;
-            ret.y = Math.sin(angle) * len;
+            return { x : Math.cos(angle) * length, y : Math.sin(angle) * length };
         }
-        else
+        else // Zero length, no direction present in the buffer.
         {
-            // Zero length, direction is not stored
-            ret.x = 0;
-            ret.y = 0;
+            return { x : 0, y : 0 };
         }
-        return ret;
     },
 
-    /** Reads a normalized 3D vector using the specified amount of bits (angle representation)
-        @method readNormalizedVector3D
-        @param {Number} numBitsYaw Number of bits to read for yaw
-        @param {Number} numBitsPitch Number of bits to read for pitch
-        @return {Object} Object with x, y, z fields, representing the 3D vector
-     */
+    /** All input parameters int.
+
+        @return {Object} { x : <value>, y : <value>, z : <value> } */
     readNormalizedVector3D : function(numBitsYaw, numBitsPitch)
     {
-        var ret = {};
         var azimuth = this.readQuantizedFloat(-Math.PI, Math.PI, numBitsYaw);
         var inclination = this.readQuantizedFloat(-Math.PI/2, Math.PI/2, numBitsPitch);
         var cx = Math.cos(inclination);
-        ret.x = cx * Math.sin(azimuth);
-        ret.y = -Math.sin(inclination);
-        ret.z = cx * Math.cos(azimuth);
-        return ret;
+        return { x : cx * Math.sin(azimuth),y : -Math.sin(inclination), z : cx * Math.cos(azimuth) };
     },
 
-    /** Reads a 3D vector using the specified amount of bits.
-        @method readVector3D
-        @param {Number} numBitsYaw Number of bits to read for yaw
-        @param {Number} numBitsPitch Number of bits to read for pitch
-        @param {Number} magnitudeIntegerBits Number of bits for magnitude integer part
-        @param {Number} magnitudeDecimalBits Number of bits for magnitude decimal part
-        @return {Object} Object with x, y, z fields, representing the 3D vector
-     */
-    readVector3D : function(numBitsYaw, numBitsPitch, magnitudeIntegerBits, magnitudeDecimalBits)
+    /** All input parameters int.
+
+        @return {Object} { x : <value>, y : <value>, z : <value> } */
+    readVector3D : function(numBitsYaw, numBitsPitch, magnitudeIntegerBits,  magnitudeDecimalBits)
     {
-        var ret = {};
+        // Read the length in unsigned fixed point format.
+        // The following line is effectively the same as calling this.readUnsignedFixedPoint, but manually perform it
+        // to be precisely able to examine whether the length is zero.
         var fp = this.readBits(magnitudeIntegerBits + magnitudeDecimalBits);
-        if (fp != 0)
+        if (fp !== 0) // If length is non-zero, the stream also contains the direction.
         {
-            var len = fp / (1 << magnitudeDecimalBits);
+            var length = fp / (1 << magnitudeDecimalBits);
+
             var azimuth = this.readQuantizedFloat(-Math.PI, Math.PI, numBitsYaw);
             var inclination = this.readQuantizedFloat(-Math.PI/2, Math.PI/2, numBitsPitch);
-            var cx = Math.cos(inclination);
-            ret.x = cx * Math.sin(azimuth) * len;
-            ret.y = -Math.sin(inclination) * len;
-            ret.z = cx * Math.cos(azimuth) * len;
-        }
-        else
-        {
-            // Zero length, direction is not stored
-            ret.x = 0;
-            ret.y = 0;
-            ret.z = 0;
-        }
 
+            var cx = Math.cos(inclination);
+            return { x : cx * Math.sin(azimuth) * length, y : -Math.sin(inclination) * length, z : cx * Math.cos(azimuth) * length };
+        }
+        else // length is zero, stream does not contain the direction.
+        {
+            return { x : 0, y : 0, z : 0 };
+        }
+    },
+    /** All input parameters int.
+
+        @return {Array} Array of 2 values. */
+    readArithmeticEncoded2 : function(numBits, max1, max2)
+    {
+        // assert(max1 * max2 < (1 << numBits));
+        var ret = [];
+        var val = this.readBits(numBits);
+        ret[1] = val % max2;
+        ret[0] = Math.floor(val / max2);
+        return ret;
+    },
+    /** All input parameters int.
+
+        @return {Array} Array of 3 values. */
+    readArithmeticEncoded3 : function(numBits, max1, max2, max3)
+    {
+        // assert(max1 * max2 * max3 < (1 << numBits));
+        var ret = [];
+        var val = this.readBits(numBits);
+        val3 = val % max3;
+        val = Math.floor(val / max3);
+        ret[1] = val % max2;
+        ret[0] = Math.floor(val / max2);
+        return ret;
+    },
+    /** All input parameters int.
+
+        @return {Array} Array of 4 values. */
+    readArithmeticEncoded4 : function(numBits, max1, max2, max3, max4)
+    {
+        // assert(max1 * max2 * max3 * max4 < (1 << numBits));
+        var ret = [];
+        var val = this.readBits(numBits);
+        ret[3] = val % max4;
+        val = Math.floor(val / max4);
+        ret[2] = val % max3;
+        val = Math.floor(val / max3);
+        ret[1] = val % max2;
+        ret[0] = Math.floor(val / max2);
+        return ret;
+    },
+    /** All input parameters int.
+
+        @return {Array} Array of 5 values. */
+    readArithmeticEncoded5 : function(numBits, max1, max2, max3, max4, max5)
+    {
+        // assert(max1 * max2 * max3 * max4 * max5 < (1 << numBits));
+        var ret = [];
+        var val = this.readBits(numBits);
+        ret[4] = val % max5;
+        val = Math.floor(val / max5);
+        ret[3] = val % max4;
+        val = Math.floor(val / max4);
+        ret[2] = val % max3;
+        val = Math.floor(val / max3);
+        ret[1] = val % max2;
+        ret[0] = Math.floor(val / max2);
         return ret;
     }
 });

--- a/src/core/data/DataDeserializer.js
+++ b/src/core/data/DataDeserializer.js
@@ -495,7 +495,7 @@ var DataDeserializer = Class.$extend(
         var shift = 0;
         var currentByte = this.data.getUint8(this.pos);
 
-        while (numBits > 0) 
+        while (numBits > 0)
         {
             if (currentByte & (1 << this.bitPos))
                 ret |= (1 << shift);
@@ -666,7 +666,7 @@ var DataDeserializer = Class.$extend(
         var inclination = this.readBits(-Math.PI/2, Math.PI/2, numBitsPitch);
         var cx = Math.cos(inclination);
         ret.x = cx * Math.sin(azimuth);
-        ret.y = -sin(inclination);
+        ret.y = -Math.sin(inclination);
         ret.z = cx * Math.cos(azimuth);
         return ret;
     },
@@ -690,7 +690,7 @@ var DataDeserializer = Class.$extend(
             var inclination = this.readBits(-Math.PI/2, Math.PI/2, numBitsPitch);
             var cx = Math.cos(inclination);
             ret.x = cx * Math.sin(azimuth) * len;
-            ret.y = -sin(inclination) * len;
+            ret.y = -Math.sin(inclination) * len;
             ret.z = cx * Math.cos(azimuth) * len;
         }
         else

--- a/src/core/data/DataSerializer.js
+++ b/src/core/data/DataSerializer.js
@@ -608,8 +608,7 @@ var DataSerializer = Class.$extend(
         @note This function performs quantization, which results in lossy serialization/deserialization. */
     writeQuantizedFloat : function(minRange, maxRange, numBits, value)
     {
-        var outVal = (MathUtils.clamp(value, minRange, maxRange) - minRange) * ((1 << numBits)-1) / (maxRange - minRange);
-        // TODO floor(outVal) as it should be u32?
+        var outVal = Math.floor((Math.min(Math.max(value, minRange), maxRange) - minRange) * ((1 << numBits)-1) / (maxRange - minRange));
         this.writeBits(outVal, numBits);
         return outVal;
     },

--- a/src/core/data/DataSerializer.js
+++ b/src/core/data/DataSerializer.js
@@ -4,16 +4,16 @@ define([
         "core/framework/TundraSDK"
     ], function(Class, TundraSDK) {
 
-/**
-    Utility class to fill in JavaScript Arraybuffer data.
-
-    @class DataSerializer
-    @constructor
-    @param {Number} numBytes Size of the destination array buffer.
-    @param {DataSerializer.ArrayType} [arrayType=Uint8] Type of the underlying typed array.
-*/
 var DataSerializer = Class.$extend(
+/** @lends DataSerializer.prototype */
 {
+    /**
+        Utility class to fill in JavaScript ArrayBuffer data.
+
+        @constructs
+        @param {Number} numBytes Size of the destination array buffer.
+        @param {DataSerializer.ArrayType} [arrayType=Uint8] Type of the underlying typed array.
+    */
     __init__ : function(numBytes, arrayType)
     {
         if (typeof numBytes !== "number")
@@ -21,8 +21,7 @@ var DataSerializer = Class.$extend(
             TundraSDK.framework.client.logWarning("[DataSerializer]: You are creating a data serializer with undefined size! Initializing size to 0 bytes.");
             numBytes = 0;
         }
-        if (arrayType === undefined || arrayType === null || typeof arrayType !== "number")
-            arrayType = DataSerializer.ArrayType.Uint8;
+        arrayType = (typeof arrayType === "number" ? arrayType : DataSerializer.ArrayType.Uint8);
 
         if (arrayType === DataSerializer.ArrayType.Uint8)
             this.array = new Uint8Array(numBytes);
@@ -40,12 +39,50 @@ var DataSerializer = Class.$extend(
             return;
         }
 
+        /**
+            @var {DataView}
+        */
         this.data = new DataView(this.array.buffer);
-        this.pos = 0;
+        /**
+            The current element we're writing to in the data buffer.
+            @var {Number}
+        */
+        this.bytePos = 0;
+        /**
+            The current bit index of the byte we're writing, [0, 7].
+            @var {Number}
+        */
+        this.bitPos = 0;
+        /**
+            Underlying data array type.
+            @var {DataSerializer.ArrayType}
+        */
+        this.type = arrayType;
+
+        // Backwards compatibility for .pos > this.readBytes() > this.bytePos
+        // Disabled due to this causing slowdown on Firefox when using DataSerializer
+        // even if the pos property is not accessed
+        /*
+        Object.defineProperties(this, {
+            pos : {
+                get : function () { return this.filledBytes(); }
+            }
+        });
+        */
     },
 
     __classvars__ :
     {
+        // For writing non-aligned floats
+        floatWriteDataView : new DataView(new ArrayBuffer(4)),
+        // For writing non-aligned doubles
+        doubleWriteDataView : new DataView(new ArrayBuffer(8)),
+
+        /**
+            @static
+            @readonly
+            @enum {number}
+        */
         ArrayType :
         {
             Uint8   : 0,
@@ -56,10 +93,11 @@ var DataSerializer = Class.$extend(
         },
 
         /**
-            Returns UTF8 byte size for a string.
+            Returns UTF-8 byte size for a string.
 
             Code adapted from https://github.com/realXtend/WebTundraNetworking/blob/master/src/DataSerializer.js
-            @method utf8StringByteSize
+
+            @static
             @param {String} str String to calculate.
             @return {Number} Number of bytes.
         */
@@ -72,10 +110,11 @@ var DataSerializer = Class.$extend(
         },
 
         /**
-            Returns UTF8 byte size for a char code.
+            Returns UTF-8 byte size for a char code.
 
             Code adapted from https://github.com/realXtend/WebTundraNetworking/blob/master/src/DataSerializer.js
-            @method utf8CharCodeByteSize
+
+            @static
             @param {Number} charCode Character code to calculate.
             @return {Number} Number of bytes.
         */
@@ -103,12 +142,12 @@ var DataSerializer = Class.$extend(
                 return 2;
             else
                 return 4;
-        }
+        },
     },
 
     /**
         Returns the destination array buffer.
-        @method getBuffer
+
         @return {ArrayBuffer} Destination array buffer.
     */
     getBuffer : function()
@@ -117,33 +156,66 @@ var DataSerializer = Class.$extend(
     },
 
     /**
-        Returns the currently written byte count.
-        @method filledBytes
-        @return {Number} Number of written bytes.
+        Returns the currently written byte count. Partial bits at the end are rounded up to constitute a full byte.
+
+        @return {Number}
     */
     filledBytes : function()
     {
-        return this.pos;
+        if (this.bitPos === 0)
+            return this.bytePos;
+        else
+            return this.bytePos + 1;
+    },
+
+    /**
+        The number of bits filled so far total.
+
+        @return {Number}
+    */
+    filledBits : function()
+    {
+        return this.bytePos * 8 + this.bitPos;
+    },
+
+    /**
+        Returns the total capacity of the buffer we are filling into, in bytes.
+
+        @return {Number}
+    */
+    capacity : function()
+    {
+        return this.data.byteLength;
     },
 
     /**
         Returns how many bytes are left for writing new data.
-        @method bytesLeft
+
         @return {Number} Number of bytes left for writing.
     */
     bytesLeft : function()
     {
-        return (this.data.byteLength - this.pos);
+        return this.bytePos >= this.data.byteLength ? 0 : this.data.byteLength - this.bytePos;
+    },
+
+    /**
+        Returns how many bits are left.
+
+        @return {Number} Number of bits left.
+    */
+    bitsLeft : function()
+    {
+        return this.bytePos >= this.data.byteLength ? 0 : (this.data.byteLength - this.bytePos) * 8 - this.bitPos;
     },
 
     skipBytes : function(numBytes)
     {
-        this.pos += numBytes;
+        this.bytePos += numBytes;
     },
 
     /**
         Writes boolean as u8, 0 if false, 1 otherwise.
-        @method writeBoolean
+
         @param {Boolean} bool Write boolean.
     */
     writeBoolean : function(bool)
@@ -153,7 +225,7 @@ var DataSerializer = Class.$extend(
 
     /**
         Writes an Uint8Array.
-        @method writeUint8Array
+
         @param {Uint8Array} buffer
     */
     writeUint8Array : function(buffer)
@@ -163,10 +235,10 @@ var DataSerializer = Class.$extend(
     },
 
     /**
-        Writes UTF8 bytes for given char code.
+        Writes UTF-8 bytes for given char code.
 
         Code adapted from https://github.com/realXtend/WebTundraNetworking/blob/master/src/DataSerializer.js
-        @method writeUtf8Char
+
         @param {Number} charCode Character code to write.
     */
     writeUtf8Char : function(charCode)
@@ -211,61 +283,62 @@ var DataSerializer = Class.$extend(
     },
 
     /**
-        Writes a size header and UTF8 bytes for given string.
+        Writes a size header and UTF-8 bytes for given string.
 
         Code adapted from https://github.com/realXtend/WebTundraNetworking/blob/master/src/DataSerializer.js
-        @method writeStringWithHeader
-        @param {Number} headerSizeBytes Size of bytes for the header size, eg. 2 == U16 size header is written. Valid options: 1, 2, 4.
+
+        @param {Number} headerSizeBytes Size of bytes for the header size, e.g. 2 == U16 size header is written.
+                        Valid options: 1, 2, 4, and any other value means that VLE is used.
+                        Use DataSerializer.vleHeaderSizeBytes(<asciiStringLength|numUtf8bytes>) if you are
+                        interested how many bytes were written in the VLE case.
         @param {String} str String to write.
-        @param {Boolean} utf8 If should write as UTF8 bytes.
+        @param {Boolean} utf8 If should write as UTF-8 bytes, ASCII otherwise.
     */
     writeStringWithHeader : function(headerSizeBytes, str, utf8)
     {
-        /// @todo Implement not writing as UTF8.
         if (typeof utf8 !== "boolean")
             utf8 = false;
 
-        // Leave room to write size header
-        var sizePos = this.pos;
-        this.pos += headerSizeBytes;
-
-        // Calculate num bytes and write string
-        var numBytes = 0;
-        for (var i = 0, len = str.length; i < len; ++i)
-        {
-            var charCode = str.charCodeAt(i);
-            numBytes += DataSerializer.utf8CharCodeByteSize(charCode);
-            this.writeUtf8Char(charCode);
-        }
-
         // Write size header
-        var preHeaderPos = this.pos;
-        this.pos = sizePos;
+        // TODO Profile if iterating the string twice causes significant overhead in UTF-8 case.
+        var numBytes = utf8 ? DataSerializer.utf8StringByteSize(str) : str.length;
         if (headerSizeBytes == 1)
             this.writeU8(numBytes);
         else if (headerSizeBytes == 2)
             this.writeU16(numBytes);
         else if (headerSizeBytes == 4)
             this.writeU32(numBytes);
-        this.pos = preHeaderPos;
+        else
+            this.writeVLE(numBytes);
+
+        var i = 0, strlen = str.length;
+        if (utf8)
+        {
+            for(; i < strlen; ++i)
+                this.writeUtf8Char(str.charCodeAt(i));
+        }
+        else
+        {
+            for(; i < strlen; ++i)
+                this.writeU8(str.charCodeAt(i)); // TODO In native impl we use s8 (char), should we use it here too?
+        }
     },
 
     /**
-        Writes a string with a VLE header depending on the string lenght. Supports UTF8 strings.
+        Writes a string with a VLE header depending on the string length. Supports UTF-8 strings.
 
-        @method writeStringVLE
+
         @param {String} str String to write.
     */
     writeStringVLE : function(str, utf8)
     {
-        this.writeStringWithHeader(DataSerializer.vleHeaderSizeBytes(str.length), str, utf8);
+        this.writeStringWithHeader(0, str, utf8);
     },
 
     /**
-        Write string with a u8 length header. Supports UTF8 strings.
-
+        Write string with a u8 length header. Supports UTF-8 strings.
         The input string has to have max length of u8, this won't be checked during runtime.
-        @method writeStringU8
+
         @param {String} str String to write.
     */
     writeStringU8 : function(str, utf8)
@@ -274,10 +347,9 @@ var DataSerializer = Class.$extend(
     },
 
     /**
-        Write string with a u16 length header. Supports UTF8 strings.
-
+        Write string with a u16 length header. Supports UTF-8 strings.
         The input string has to have max length of u16, this won't be checked during runtime.
-        @method writeStringU16
+
         @param {String} str String to write.
     */
     writeStringU16 : function(str, utf8)
@@ -286,10 +358,9 @@ var DataSerializer = Class.$extend(
     },
 
     /**
-        Write string with a u32 length header. Supports UTF8 strings.
-
+        Write string with a u32 length header. Supports UTF-8 strings.
         The input string has to have max length of u32, this won't be checked during runtime.
-        @method writeStringU32
+
         @param {String} str String to write.
     */
     writeStringU32 : function(str, utf8)
@@ -299,95 +370,142 @@ var DataSerializer = Class.$extend(
 
     /**
         Writes s8.
-        @method writeS8
-        @param {byte} s8
+
+        @param {Number} value
     */
-    writeS8 : function(s8)
+    writeS8 : function(value)
     {
-        this.data.setInt8(this.pos, s8);
-        this.pos += 1;
+        if (this.bitPos === 0)
+        {
+            this.data.setInt8(this.bytePos, value);
+            this.bytePos += 1;
+        }
+        else
+            this.writeBits(value, 8);
     },
 
     /**
         Writes u8.
-        @method writeU8
-        @param {unsigned byte} u8
+
+        @param {Number} value
     */
-    writeU8 : function(u8)
+    writeU8 : function(value)
     {
-        this.data.setUint8(this.pos, u8);
-        this.pos += 1;
+        if (this.bitPos === 0)
+        {
+            this.data.setUint8(this.bytePos, value);
+            this.bytePos += 1;
+        }
+        else
+            this.writeBits(value, 8);
     },
 
     /**
         Writes s16.
-        @method writeS16
-        @param {short} s16
+
+        @param {Number} value
     */
-    writeS16 : function(s16)
+    writeS16 : function(value)
     {
-        this.data.setInt16(this.pos, s16, true);
-        this.pos += 2;
+        if (this.bitPos === 0)
+        {
+            this.data.setInt16(this.bytePos, value, true);
+            this.bytePos += 2;
+        }
+        else
+            this.writeBits(value, 16);
     },
 
     /**
         Writes u16.
-        @method writeU16
-        @param {unsigned short} u16
+
+        @param {Number} value
     */
-    writeU16 : function(u16)
+    writeU16 : function(value)
     {
-        this.data.setUint16(this.pos, u16, true);
-        this.pos += 2;
+        if (this.bitPos === 0)
+        {
+            this.data.setUint16(this.bytePos, value, true);
+            this.bytePos += 2;
+        }
+        else
+            this.writeBits(value, 16);
     },
 
     /**
         Writes s32.
-        @method writeS32
-        @param {long} s32
+
+        @param {Number} value
     */
-    writeS32 : function(s32)
+    writeS32 : function(value)
     {
-        this.data.setInt32(this.pos, s32, true);
-        this.pos += 4;
+        if (this.bitPos === 0)
+        {
+            this.data.setIn32(this.bytePos, value, true);
+            this.bytePos += 4;
+        }
+        else
+            this.writeBits(value, 32);
     },
 
     /**
         Writes u32.
-        @method writeU32
-        @param {unsigned long} u32
+
+        @param {Number} value
     */
-    writeU32 : function(u32)
+    writeU32 : function(value)
     {
-        this.data.setUint32(this.pos, u32, true);
-        this.pos += 4;
+        if (this.bitPos === 0)
+        {
+            this.data.setUint32(this.bytePos, value, true);
+            this.bytePos += 4;
+        }
+        else
+            this.writeBits(value, 32);
     },
 
     /**
         Writes f32.
-        @method writeFloat32
-        @param {float} f32
+
+        @param {Number} value
     */
-    writeFloat32 : function(f32)
+    writeFloat32 : function(value)
     {
-        this.data.setFloat32(this.pos, f32, true);
-        this.pos += 4;
+        if (this.bitPos === 0)
+        {
+            this.data.setFloat32(this.bytePos, value, true);
+            this.bytePos += 4;
+        }
+        else
+        {
+            DataSerializer.floatWriteDataView.setFloat32(0, value, true);
+            this.writeBits(DataSerializer.floatWriteDataView.getUint32(0, true), 32);
+        }
     },
 
     /**
         Writes f64.
-        @method writeFloat64
-        @param {double} f64
+
+        @param {Number} value
     */
-    writeFloat64 : function(f64)
+    writeFloat64 : function(value)
     {
-        this.data.setFloat64(this.pos, f64, true);
-        this.pos += 8;
+        if (this.bitPos === 0)
+        {
+            this.data.setFloat64(this.bytePos, value, true);
+            this.bytePos += 8;
+        }
+        else
+        {
+            DataSerializer.doubleWriteDataView.setFloat64(0, value, true);
+            this.writeBits(DataSerializer.doubleWriteDataView.getUint32(0, true), 32);
+            this.writeBits(DataSerializer.doubleWriteDataView.getUint32(4, true), 32);
+        }
     },
 
     /**
         Writes VLE.
-        @method writeVLE
+
         @param {Number} value Value to write as VLE.
     */
     writeVLE : function(value)
@@ -409,28 +527,240 @@ var DataSerializer = Class.$extend(
     },
 
     /**
-        Writes bytes as bits.
-        @method writeBits
-        @param {Number} bytes How many bytes to write as bits.
-        @return {BitArray} Read bits. See http://github.com/bramstein/bit-array
+        Writes the given number of bits to the stream.
+
+        @param {Number} value The variable where the bits are taken from. The bits are read from the LSB first, towards the MSB end of the value.
+        @param {Number} numBits The number of bits to write, in the range [1, 32].
     */
-    writeBits : function(bytes)
+    writeBits : function(value, numBits)
     {
-        /*
-        var bitIndex = 0;
-        var bits = new BitArray(bytes*8, 0);
-        for (var byteIndex=0; byteIndex<bytes; ++byteIndex)
+        var shift = 0;
+        var currentByte = this.data.getUint8(this.bytePos);
+
+        while(numBits > 0)
         {
-            var byte = this.readU8();
-            for (var i=0; i<8; ++i)
+            if (value & (1 << shift))
+                currentByte |= (1 << this.bitPos);
+            else
+                currentByte &= (0xff - (1 << this.bitPos));
+
+            shift++;
+            numBits--;
+            this.bitPos++;
+
+            if (this.bitPos > 7)
             {
-                var bit = (~~byte & 1 << i) > 0 ? 1 : 0;
-                bits.set(bitIndex, bit);
-                bitIndex++;
+                this.bitPos = 0;
+                this.data.setUint8(this.bytePos, currentByte);
+                this.bytePos++;
+                if (numBits > 0)
+                    currentByte = this.data.getUint8(this.bytePos);
             }
         }
-        return bits;
-        */
+
+        if (this.bitPos !== 0)
+            this.data.setUint8(this.bytePos, currentByte);
+    },
+
+    /** Writes the given non-negative float quantized to the given fixed-point precision.
+        @param value The floating-point value to send. This float must have a value in the range [0, 2^numIntegerBits[.
+        @param numIntegerBits The number (integer) of bits to use to represent the integer part.
+        @param numDecimalBits The number (integer) of bits to use to represent the fractional part.
+        @note Before writing the value, it is clamped to range specified above to ensure that the written value does not
+        result in complete garbage due to over/underflow.
+        @note The total number of bits written is numIntegerBits + numDecimalBits, which must in total be <= 32.
+        @return The bit pattern that was written to the buffer. */
+    writeUnsignedFixedPoint : function(numIntegerBits, numDecimalBits, value)
+    {
+        // assert(numIntegerBits >= 0);
+        // assert(numDecimalBits > 0);
+        // assert(numIntegerBits + numDecimalBits <= 32);
+        var maxVal = (1 << numIntegerBits);
+        var maxBitPattern = (1 << (numIntegerBits + numDecimalBits)) - 1; // All ones - the largest value we can send.
+        var outVal = value <= 0 ? 0 : (value >= maxVal ? maxBitPattern : (value * (1 << numDecimalBits)));
+        // TODO floor(outVal) as it should be u32?
+        // assert(outVal <= maxBitPattern);
+        this.writeBits(outVal, numIntegerBits + numDecimalBits);
+        return outVal;
+    },
+
+    /** Writes the given float quantized to the given fixed-point precision.
+        @param value The floating-point value to send. This float must have a value in the range [-2^(numIntegerBits-1), 2^(numIntegerBits-1)[.
+        @param numIntegerBits The number (integer) of bits to use to represent the integer part.
+        @param numDecimalBits The number (integer) of bits to use to represent the fractional part.
+        @note Before writing the value, it is clamped to range specified above to ensure that the written value does not
+        result in complete garbage due to over/underflow.
+        @note The total number of bits written is numIntegerBits + numDecimalBits, which must in total be <= 32.
+        @return The bit pattern that was written to the buffer. */
+    writeSignedFixedPoint : function(numIntegerBits, numDecimalBits, value)
+    {
+        // Adding a [-k, k-1] range -> remap to unsigned.[0, 2k-1] range and send that instead.
+        return this.writeUnsignedFixedPoint(numIntegerBits, numDecimalBits, value + (1 << (numIntegerBits-1)));
+    },
+
+    /** Writes the given float quantized to the number of bits, that are distributed evenly over the range [minRange, maxRange].
+        @param value The floating-point value to send. This float must have a value in the range [minRange, maxRange].
+        @param numBits The number of bits to use for representing the value. The total number of different values written is then 2^numBits,
+        which are evenly distributed across the range [minRange, maxRange]. The value numBits must satisfy 1 <= numBits <= 30.
+        @param minRange The lower limit for the value that is being written.
+        @param maxRange The upper limit for the value that is being written.
+        @return The bit pattern that was written to the buffer.
+        @note This function performs quantization, which results in lossy serialization/deserialization. */
+    writeQuantizedFloat : function(minRange, maxRange, numBits, value)
+    {
+        var outVal = (MathUtils.clamp(value, minRange, maxRange) - minRange) * ((1 << numBits)-1) / (maxRange - minRange);
+        // TODO floor(outVal) as it should be u32?
+        this.writeBits(outVal, numBits);
+        return outVal;
+    },
+    /** Writes the given normalized 2D vector compressed to a single 1D polar angle value. Then the angle is quantized to the specified
+        precision.
+        @param x The x coordinate of the 2D vector.
+        @param y The y coordinate of the 2D vector.
+        @param numBits The number (integer) of bits to quantize the representation down to. This value must satisfy 1 <= numBits <= 30.
+        @note The vector (x,y) does not need to be normalized for this function to work properly (don't bother enforcing normality in
+        advance prior to calling this). When deserializing, (x,y) is reconstructed as a normalized direction vector.
+        @note Do not call this function with (x,y) == (0,0).
+        @note This function performs quantization, which results in lossy serialization/deserialization. */
+    writeNormalizedVector2D : function(x, y, numBits)
+    {
+        // Call atan2() to get the aimed angle of the 2D vector in the range [-Math.PI, Math.PI], then quantize the 1D result to the desired precision.
+        this.writeQuantizedFloat(-Math.PI, Math.PI, numBits, atan2(y, x));
+    },
+    /** Writes the given 2D vector in polar form and quantized to the given precision.
+        The length of the 2D vector is stored as fixed-point in magnitudeIntegerBits.magnitudeDecimalBits format.
+        The direction of the 2D vector is stores with directionBits.
+        @param x The x coordinate of the 2D vector.
+        @param y The y coordinate of the 2D vector.
+        @param magnitudeIntegerBits The number of bits to use for the integral part of the vector's length. This means
+        that the maximum length of the vector to be written by this function is < 2^magnitudeIntegerBits.
+        @param magnitudeDecimalBits The number of bits to use for the fractional part of the vector's length.
+        @param directionBits The number of bits of precision to use for storing the direction of the 2D vector.
+        @return The number of bits written to the stream.
+        @important This function does not write a fixed amount of bits to the stream, but omits the direction if the length is zero.
+        Therefore only use DataDeserializer.readVector2D to extract the vector from the buffer. */
+    // float x, float y, int magnitudeIntegerBits, int magnitudeDecimalBits, int directionBits
+    // returns The number of bits written to the stream.
+    writeVector2D : function(x, y, magnitudeIntegerBits, magnitudeDecimalBits, directionBits)
+    {
+        // Compute the length of the vector. Use a fixed-point representation to store the length.
+        var length = Math.sqrt(x*x+y*y);
+        var bitVal = this.writeUnsignedFixedPoint(magnitudeIntegerBits, magnitudeDecimalBits, length);
+
+        // If length == 0, don't need to send the angle, as it's a zero vector.
+        if (bitVal !== 0)
+        {
+            // Call atan2() to get the aimed angle of the 2D vector in the range [-Math.PI, Math.PI], then quantize the 1D result to the desired precision.
+            var angle = Math.atan2(y, x);
+            this.writeQuantizedFloat(-Math.PI, Math.PI, directionBits, angle);
+            return magnitudeIntegerBits + magnitudeDecimalBits + directionBits;
+        }
+        else
+            return magnitudeIntegerBits + magnitudeDecimalBits;
+    },
+    /** Writes the given normalized 3D vector converted to spherical form (azimuth/yaw, inclination/pitch) and quantized to the specified range.
+        The given vector (x,y,z) must be normalized in advance.
+        @param numBitsYaw The number (integer) of bits to use for storing the azimuth/yaw part of the vector.
+        @param numBitsPitch The number (integer) of bits to use for storing the inclination/pitch part of the vector.
+        @note After converting the euclidean (x,y,z) to spherical (yaw, pitch) format, the yaw value is expressed in the range [-pi, pi] and pitch
+        is expressed in the range [-pi/2, pi/2]. Therefore, to maintain consistent precision, the condition numBitsYaw == numBitsPitch + 1
+        should hold. E.g. If you specify 8 bits for numBitsPitch, then you should specify 9 bits for numBitsYaw to have yaw & pitch use the same
+        amount of precision.
+        @note This function uses the convention that the +Y axis points towards up, i.e. +Y is the "Zenith direction", and the X-Z plane is the horizontal
+        "map" plane. */
+    writeNormalizedVector3D : function(x, y, z, numBitsYaw, numBitsPitch)
+    {
+        // Convert to spherical coordinates. We assume that the vector (x,y,z) has been normalized beforehand.
+        var azimuth = Math.atan2(x, z); // The 'yaw'
+        var inclination = Math.asin(-y); // The 'pitch'
+
+        this.writeQuantizedFloat(-Math.PI, Math.PI, numBitsYaw, azimuth);
+        this.writeQuantizedFloat(-Math.PI/2, Math.PI/2, numBitsPitch, inclination);
+    },
+    /** Writes the given 3D vector converted to spherical form (azimuth/yaw, inclination/pitch, length) and quantized to the specified range.
+        @param numBitsYaw The number of bits to use for storing the azimuth/yaw part of the vector.
+        @param numBitsPitch The number of bits to use for storing the inclination/pitch part of the vector.
+        @param magnitudeIntegerBits The number of bits to use for the integral part of the vector's length. This means
+        that the maximum length of the vector to be written by this function is < 2^magnitudeIntegerBits.
+        @param magnitudeDecimalBits The number of bits to use for the fractional part of the vector's length.
+        @return The number of bits written to the stream.
+        @important This function does not write a fixed amount of bits to the stream, but omits the direction if the length is zero.
+        Therefore only use DataDeserializer.readVector3D to extract the vector from the buffer.
+        @note After converting the euclidean (x,y,z) to spherical (yaw, pitch) format, the yaw value is expressed in the range [-pi, pi] and pitch
+        is expressed in the range [-pi/2, pi/2]. Therefore, to maintain consistent precision, the condition numBitsYaw == numBitsPitch + 1
+        should hold. E.g. If you specify 8 bits for numBitsPitch, then you should specify 9 bits for numBitsYaw to have yaw & pitch use the same
+        amount of precision.
+        @note This function uses the convention that the +Y axis points towards up, i.e. +Y is the "Zenith direction", and the X-Z plane is the horizontal
+        "map" plane. */
+    writeVector3D : function(x, y, z, numBitsYaw, numBitsPitch, magnitudeIntegerBits, magnitudeDecimalBits)
+    {
+        var length = Math.sqrt(x*x + y*y + z*z);
+        var bitVal = this.writeUnsignedFixedPoint(magnitudeIntegerBits, magnitudeDecimalBits, length);
+        if (bitVal !== 0)
+        {
+            // The written length was not zero. Send the spherical angles as well.
+            var azimuth = Math.atan2(x, z);
+            var inclination = Math.asin(-y / length);
+
+            this.writeQuantizedFloat(-Math.PI, Math.PI, numBitsYaw, azimuth);
+            this.writeQuantizedFloat(-Math.PI/2, Math.PI/2, numBitsPitch, inclination);
+            return magnitudeIntegerBits + magnitudeDecimalBits + numBitsYaw + numBitsPitch;
+        }
+        else // The vector is (0,0,0). Don't send spherical angles as they're redundant.
+            return magnitudeIntegerBits + magnitudeDecimalBits;
+    },
+
+    /** All values ints */
+    writeArithmeticEncoded2 : function(numBits, val1, max1, val2, max2)
+    {
+        // assert(max1 * max2 < (1 << numBits));
+        // assert(val1 >= 0);
+        // assert(val1 < max1);
+        // assert(val2 >= 0);
+        // assert(val2 < max2);
+        this.writeBits(val1 * max2 + val2, numBits);
+    },
+    /** All values ints */
+    writeArithmeticEncoded3 : function(numBits, val1, max1, val2, max2, val3, max3)
+    {
+        // assert(max1 * max2 * max3 < (1 << numBits));
+        // assert(val1 >= 0);
+        // assert(val1 < max1);
+        // assert(val2 >= 0);
+        // assert(val2 < max2);
+        // assert(val3 >= 0);
+        // assert(val3 < max3);
+        this.writeBits((val1 * max2 + val2) * max3 + val3, numBits);
+    },
+    /** All values ints */
+    writeArithmeticEncoded4 : function(numBits, val1, max1, val2, max2, val3, max3, val4, max4)
+    {
+        // assert(max1 * max2 * max3 * max4 < (1 << numBits));
+        // assert(val1 >= 0);
+        // assert(val1 < max1);
+        // assert(val2 >= 0);
+        // assert(val2 < max2);
+        // assert(val3 >= 0);
+        // assert(val3 < max3);
+        // assert(val4 >= 0);
+        // assert(val4 < max4);
+        this.writeBits(((val1 * max2 + val2) * max3 + val3) * max4 + val4, numBits);
+    },
+    /** All values ints */
+    writeArithmeticEncoded5 : function(numBits, val1, max1, val2, max2, val3, max3, val4, max4, val5, max5)
+    {
+        // assert(max1 * max2 * max3 * max4 * max5 < (1 << numBits));
+        // assert(val1 >= 0);
+        // assert(val1 < max1);
+        // assert(val2 >= 0);
+        // assert(val2 < max2);
+        // assert(val3 >= 0);
+        // assert(val3 < max3);
+        // assert(val4 >= 0);
+        // assert(val4 < max4);
+        // assert(val5 >= 0);
+        // assert(val5 < max5);
+        this.writeBits((((val1 * max2 + val2) * max3 + val3) * max4 + val4) * max5 + val5, numBits);
     }
 });
 

--- a/src/core/framework/TundraClient.js
+++ b/src/core/framework/TundraClient.js
@@ -261,6 +261,12 @@ var TundraClient = Class.$extend(
             @type Boolean
         */
         this.networkDebugLogging = params.networkDebugLogging;
+        /**
+            Network protocol version supported by the server
+            @property protocolVersion
+            @type Number
+        */
+        this.protocolVersion = Network.protocolVersion.Original;
 
         // Reset state
         this.reset();

--- a/src/core/network/LoginMessage.js
+++ b/src/core/network/LoginMessage.js
@@ -1,8 +1,9 @@
 
 define([
         "core/network/INetworkMessage",
+        "core/network/Network",
         "core/data/DataSerializer"
-    ], function(INetworkMessage, DataSerializer) {
+    ], function(INetworkMessage, Network, DataSerializer) {
 
 /**
     Login message.
@@ -32,9 +33,10 @@ var LoginMessage = INetworkMessage.$extend(
     */
     serialize : function(loginData)
     {
-        this.$super(2 + 2 + DataSerializer.utf8StringByteSize(loginData));
+        this.$super(2 + 2 + DataSerializer.utf8StringByteSize(loginData) + 1);
         this.ds.writeU16(this.id);
         this.ds.writeStringU16(loginData);
+        this.ds.writeVLE(Network.protocolVersions.ProtocolOriginal);
     }
 });
 

--- a/src/core/network/LoginMessage.js
+++ b/src/core/network/LoginMessage.js
@@ -36,7 +36,7 @@ var LoginMessage = INetworkMessage.$extend(
         this.$super(2 + 2 + DataSerializer.utf8StringByteSize(loginData) + 1);
         this.ds.writeU16(this.id);
         this.ds.writeStringU16(loginData);
-        this.ds.writeVLE(Network.protocolVersions.ProtocolOriginal);
+        this.ds.writeVLE(Network.protocolVersions.ProtocolWebClientRigidBodyMessage);
     }
 });
 

--- a/src/core/network/LoginMessage.js
+++ b/src/core/network/LoginMessage.js
@@ -36,7 +36,8 @@ var LoginMessage = INetworkMessage.$extend(
         this.$super(2 + 2 + DataSerializer.utf8StringByteSize(loginData) + 1);
         this.ds.writeU16(this.id);
         this.ds.writeStringU16(loginData);
-        this.ds.writeVLE(Network.protocolVersions.ProtocolWebClientRigidBodyMessage);
+        // Request highest possible protocol version, see if server supports it
+        this.ds.writeVLE(Network.protocolVersion.WebClientRigidBodyMessage);
     }
 });
 

--- a/src/core/network/LoginReplyMessage.js
+++ b/src/core/network/LoginReplyMessage.js
@@ -1,7 +1,8 @@
 
 define([
         "core/network/INetworkMessage",
-    ], function(INetworkMessage) {
+        "core/network/Network"
+    ], function(INetworkMessage, Network) {
 
 /**
     Login reply message.
@@ -34,6 +35,12 @@ var LoginReplyMessage = INetworkMessage.$extend(
             @type String
         */
         this.replyData = "";
+        /**
+            Protocol version supported by the server
+            @property protocolVersion
+            @type Number
+        */
+        this.protocolVersion = Network.protocolVersion.Original;
     },
 
     __classvars__ :
@@ -47,6 +54,9 @@ var LoginReplyMessage = INetworkMessage.$extend(
         this.success = ds.readBoolean();
         this.connectionId = ds.readVLE();
         this.replyData = ds.readStringU16();
+        // Read optional protocol version if present
+        if (ds.bytesLeft() >= 1)
+            this.protocolVersion = ds.readVLE();
         delete ds;
     }
 });

--- a/src/core/network/Network.js
+++ b/src/core/network/Network.js
@@ -81,6 +81,17 @@ var Network = Class.$extend(
             41  : "EC_SlideShow",               52  : "EC_GraphicsViewCanvas",
             42  : "EC_WidgetBillboard",         108 : "EC_StencilGlow",
             43  : "EC_PhysicsMotor"
+        },
+
+        /**
+            Network protocol versions
+        */
+        protocolVersions:
+        {
+            ProtocolOriginal : 1,
+            ProtocolCustomComponents : 2,
+            ProtocolHierarchicScene : 3,
+            ProtocolWebClientRigidBodyMessage : 4
         }
     },
 

--- a/src/core/network/Network.js
+++ b/src/core/network/Network.js
@@ -86,12 +86,12 @@ var Network = Class.$extend(
         /**
             Network protocol versions
         */
-        protocolVersions:
+        protocolVersion:
         {
-            ProtocolOriginal : 1,
-            ProtocolCustomComponents : 2,
-            ProtocolHierarchicScene : 3,
-            ProtocolWebClientRigidBodyMessage : 4
+            Original : 1,
+            CustomComponents : 2,
+            HierarchicScene : 3,
+            WebClientRigidBodyMessage : 4
         }
     },
 

--- a/src/core/network/ObserverPositionMessage.js
+++ b/src/core/network/ObserverPositionMessage.js
@@ -1,0 +1,79 @@
+
+define([
+        "core/network/INetworkMessage",
+        "core/network/Network",
+        "core/data/DataSerializer"
+    ], function(INetworkMessage, Network, DataSerializer) {
+
+/**
+    Login message.
+
+    @class ObserverPositionMessage
+    @extends INetworkMessage
+    @constructor
+*/
+var ObserverPositionMessage = INetworkMessage.$extend(
+{
+    __init__ : function()
+    {
+        this.$super(ObserverPositionMessage.id, "ObserverPositionMessage");
+    },
+
+    __classvars__ :
+    {
+        id   : 105,
+        name : "ObserverPositionMessage"
+    },
+
+    /**
+        Serializes observer position & orientation to this message.
+
+        @method serialize
+        @param {THREE.Vector3} position Observer position
+        @param {THREE.Quaternion} orientation Observer orientation
+    */
+    serialize : function(position, orientation)
+    {
+        this.$super(4 + 1 + 6 * 4);
+        this.ds.writeU16(this.id);
+        this.ds.writeVLE(0); // Todo: use proper scene ID
+        var posSendType = 2; // Full. Todo: detect minimal size as necessary
+        var rotSendType = 3; // 3 DOF. Todo: detect minimal size as necessary
+        this.ds.writeArithmeticEncoded2(8, posSendType, 3, rotSendType, 4);
+        this.ds.writeFloat32(position.x);
+        this.ds.writeFloat32(position.y);
+        this.ds.writeFloat32(position.z);
+        
+        // Angle-axis decompose from MathGeoLib
+        var angle = Math.acos(orientation.w) * 2;
+        var sinz = Math.sin(angle/2);
+        var axis = {};
+        if (Math.abs(sinz) > 0.00001)
+        {
+            sinz = 1 / sinz;
+            axis.x = orientation.x * sinz;
+            axis.y = orientation.y * sinz;
+            axis.z = orientation.z * sinz;
+        }
+        else
+        {
+            angle = 0;
+            axis.x = 1;
+            axis.y = 0;
+            axis.z = 0;
+        }
+        if (angle >= Math.PI)
+        {
+            axis.x = -axis.x;
+            axis.y = -axis.y;
+            axis.z = -axis.z;
+            angle = 2 * Math.PI - angle;
+        }
+        this.ds.writeQuantizedFloat(0, Math.PI, 10, angle);
+        this.ds.writeNormalizedVector3D(axis.x, axis.y, axis.z, 11, 10);
+    }
+});
+
+return ObserverPositionMessage;
+
+}); // require js

--- a/src/core/network/TundraMessageHandler.js
+++ b/src/core/network/TundraMessageHandler.js
@@ -72,8 +72,9 @@ var TundraMessageHandler = INetworkMessageHandler.$extend(
 
             if (msg.success)
             {
-                // Set the clients connection id.
+                // Set the clients connection id and supported protocol version
                 client.connectionId = msg.connectionId;
+                client.protocolVersion = msg.protocolVersion;
 
                 // Pass storage information to AssetAPI.
                 if (msg.loginReplyData !== "")

--- a/src/core/network/TundraMessageHandler.js
+++ b/src/core/network/TundraMessageHandler.js
@@ -37,7 +37,7 @@ var TundraMessageHandler = INetworkMessageHandler.$extend(
             return true;
         // Scene/Entity/Component/Attribute related.
         // Expand this when new messages handling is implemented.
-        else if (id >= 110 && id <= 116)
+        else if ((id >= 110 && id <= 116) || id == 119)
             return true;
         return false;
     },
@@ -47,17 +47,16 @@ var TundraMessageHandler = INetworkMessageHandler.$extend(
         /// @todo Implement 109 EditEntityPropertiesMessage
         /// @todo Implement 117 CreateEntityReplyMessage
         /// @todo Implement 118 CreateComponentsReplyMessage
-        /// @todo Implement 119 RigidBodyUpdateMessage
 
         var client = TundraSDK.framework.client;
 
-        if (id >= 110 && id <= 116)
+        if ((id >= 110 && id <= 116) || id == 119)
         {
             // Immediate mode message parsing, no predefined objects.
             var msg = new INetworkMessage(id);
             msg.deserialize(ds);
 
-            client.scene.onTundraMessage(msg);   
+            client.scene.onTundraMessage(msg);
         }
         else if (id === EntityActionMessage.id)
         {

--- a/src/core/scene/Scene.js
+++ b/src/core/scene/Scene.js
@@ -1167,7 +1167,7 @@ var Scene = Class.$extend(
             var scaleSendType = sendTypes[2];
             var velSendType = sendTypes[3];
             var angVelSendType = sendTypes[4];
-
+            
             if (posSendType == 1)
             {
                 t.setPosition(ds.readSignedFixedPoint(11, 8), ds.readSignedFixedPoint(11, 8), ds.readSignedFixedPoint(11, 8));
@@ -1185,7 +1185,7 @@ var Scene = Class.$extend(
             else if (rotSendType == 2)
             {
                 var forward3D = ds.readNormalizedVector3D(9, 8);
-                t.lookAt(new THREE.Vector3(0,0,0), new THREE.Vector3(forward3D.x, forward3D.y, forward2D.z));
+                t.lookAt(new THREE.Vector3(0,0,0), new THREE.Vector3(forward3D.x, forward3D.y, forward3D.z));
             }
             else if (rotSendType == 3)
             {
@@ -1228,7 +1228,10 @@ var Scene = Class.$extend(
             if (angVelSendType == 1)
             {
                 var angle = ds.readBits(10);
-                var axis = ds.readNormalizedVector3D(11, 10);
+                if (angle != 0)
+                {
+                    var axis = ds.readNormalizedVector3D(11, 10);
+                }
             }
 
             if (placeable && (posSendType != 0 || rotSendType != 0 || scaleSendType != 0))

--- a/src/core/scene/Scene.js
+++ b/src/core/scene/Scene.js
@@ -1,6 +1,7 @@
 
 define([
         "lib/classy",
+        "lib/three",
         "core/framework/TundraSDK",
         "core/framework/TundraLogging",
         "core/framework/CoreStringUtils",
@@ -12,7 +13,7 @@ define([
         "core/data/DataDeserializer",
         "core/data/DataSerializer",
         "core/math/Transform"
-    ], function(Class, TundraSDK, TundraLogging, CoreStringUtils, Entity, IComponent, Attribute, AttributeChange, Network, DataDeserializer, DataSerializer, Transform) {
+    ], function(Class, THREE, TundraSDK, TundraLogging, CoreStringUtils, Entity, IComponent, Attribute, AttributeChange, Network, DataDeserializer, DataSerializer, Transform) {
 
 /**
     Scene that is accessible from {{#crossLink "TundraClient/scene:property"}}TundraClient.scene{{/crossLink}}

--- a/src/core/scene/Scene.js
+++ b/src/core/scene/Scene.js
@@ -970,8 +970,6 @@ var Scene = Class.$extend(
         var parentEntityId = 0;
         if (TundraSDK.framework.client.protocolVersion >= Network.protocolVersion.HierarchicScene)
             parentEntityId = ds.readU32();
-        else
-            console.log("Hierarchic scene not supported, skipping parentid");
 
         // Components
         var numComponents = ds.readVLE();
@@ -1171,7 +1169,7 @@ var Scene = Class.$extend(
                 // The message parsing will continue regardless, we just read the correct amount of bits
             }
 
-            var sendTypes = ds.readArithmeticEncoded(8, 3, 4, 3, 3, 2);
+            var sendTypes = ds.readArithmeticEncoded5(8, 3, 4, 3, 3, 2);
             var posSendType = sendTypes[0];
             var rotSendType = sendTypes[1];
             var scaleSendType = sendTypes[2];


### PR DESCRIPTION
These changes are packed into one PR because they both depend on improved DataDeserializer / DataSerializer functionality.

- Send client protocol version to the server on login. A new protocol version was created, which implies rigidbody message understanding in the websocket client. The corresponding Tundra commit is https://github.com/realXtend/tundra/commit/146abbb853c6758f68d8c6009c5a45bbebac6f5b
- DataSerializer & DataDeserializer with @Stinkfist0's changes + further improvements
- As a result of the previous, simplified EditAttributes message handling
- Read parent entity id in CreateEntity message if protocol supports it. Is not used yet, but was needed as supporting a new protocol version implies supporting all the previous versions too.
- Handling of rigidbody update message. Does not store velocities yet, or interpolate, but handles the various bit-level encodings properly.
- Optionally send pos / rot of an observer entity at a regular rate, if changed, for interest management. This is for now implemented directly in the Client class, but can be factored into a separate class if necessary.