### PR TITLE
dev2 three.json SkinnedMesh loading w.i.p.

### DIFF
--- a/src/view/threejs/asset/ThreeJsonAsset.js
+++ b/src/view/threejs/asset/ThreeJsonAsset.js
@@ -144,7 +144,17 @@ var ThreeJsonAsset = IAsset.$extend(
                     material = (threejsData.materials.length === 1 ? threejsData.materials[0] : new THREE.MeshFaceMaterial(threejsData.materials));
 
                 this.mesh = TundraSDK.framework.renderer.createSceneNode();
-                this.mesh.add(new THREE.Mesh(threejsData.geometry, material));
+                
+                var threeMesh = undefined;
+                if (threejsData.geometry.bones !== undefined && threejsData.geometry.bones.length > 0) {
+                    threeMesh = new THREE.SkinnedMesh(threejsData.geometry, material);
+                    material.skinning = true;
+		}
+                else {
+                    threeMesh = new THREE.Mesh(threejsData.geometry, material)
+                }
+
+                this.mesh.add(threeMesh); //this.mesh is confusingly named: is not a mesh but an object3d parent for mesh
             }
             else
                 this.log.error("Parsing failed, three.js didnt return a valid geometry for", this.name);

--- a/src/view/threejs/entity-components/EC_Mesh_ThreeJs.js
+++ b/src/view/threejs/entity-components/EC_Mesh_ThreeJs.js
@@ -174,6 +174,7 @@ var EC_Mesh_ThreeJs = EC_Mesh.$extend(
                 }
             }
 
+/*
             // Apply materials
             var materialRefs = this.attributes.materialRefs.get();
             var numSubmeshes = this.meshAsset.numSubmeshes();
@@ -199,12 +200,14 @@ var EC_Mesh_ThreeJs = EC_Mesh.$extend(
                 submesh.receiveShadow = (submesh.material.hasTundraShadowShader !== undefined && submesh.material.hasTundraShadowShader === true);
                 submesh.castShadow = this.castShadows;
             }
+
             if (this.materialAssets.length > numSubmeshes)
             {
                 this.log.warnC("Too many materials for target mesh " + this.meshAsset.name + ". Materials: " +
                     this.materialAssets.length + " Submeshes: " + numSubmeshes + " In entity: " + this.parentEntity.id + " " +
                         this.parentEntity.name);
             }
+*/
         }
 
         // Parent this meshes scene node to EC_Placeable scene node


### PR DESCRIPTION
WIP for implementing #78 - see motivation and info about the test for this etc. there.

Not ready to merge but am opening for discussion.

Had to disable material setting in `EC_Mesh_ThreeJs` as it overrode the material from the three.json

I think overall with the current `EC_Mesh_ThreeJs` implementation, the skeleton & material ref handling codes there, there's a bit of a conflict with the three json (and gltf and others) mesh format where the same file includes skels and animations.

dev2 `EC_Mesh_ThreeJs` is written for Ogre assets where those are separate. Thus much of the EC impl is dealing with loading those other files and applying them etc.

If we recommend use of Three assets, and don't even have the Ogre asset loading available, one way would be indeed to just remove those parts that overwrite the loaded material now. But that may make things difficult for where Ogre assets are used so perhaps what's needed is to make `EC_Mesh_ThreeJs` somehow work for both cases: not overwrite with default white when the mesh already has the correct material.

I'll check if can do that next but am open for other ideas too. If this one EC impl becomes too complex while handling both cases, perhaps the Ogre things could be moved to some `EC_Mesh_ThreeJsFromOgreAssets` class or so. But perhaps a simple check for existing material does it simply enough.

Also, the animation data seemed to be lost somewhere -- am not sure if that's due to the ancient three.js in dev2 still (r62 vs 72dev with which have tested the deer export now otherwise) or if something in the loading & ec mechanism still overrides that.