### PR TITLE
port util to create webtundra js attrdefs from tundra c++ sources to v2.

### DIFF
--- a/tools/util/ecgen.py
+++ b/tools/util/ecgen.py
@@ -4,11 +4,17 @@ import re
 
 typetrans = {
     'float': 'Real',
-    'qstring': 'String',
-    'qvariantlist': 'QVariantList',
-    'qvariant': 'QVariant',
+    'bool': 'Bool'
+    #'qstring': 'String',
+    #'qvariantlist': 'QVariantList',
+    #'qvariant': 'QVariant'
 }
 
+attrtemplate = """        /**
+            @property %s (attribute)
+            @type Attribute
+        */
+        this.declareAttribute(%d, "%s", %s, %s, "%s");"""
 
 def main():
     for input_fn in sys.argv[1:]:
@@ -17,6 +23,7 @@ def main():
 def gen_ec(filename):
     attr_defaults= read_defaults(re.sub(r'\.h$', '.cpp', filename))
 
+    aidx = 0
     for line in open(filename):
         m = re.search(r'COMPONENT_NAME\("(\w+)", (\d+)', line)
         if m:
@@ -31,13 +38,16 @@ def gen_ec(filename):
         m = re.search(r'DEFINE_QPROPERTY_ATTRIBUTE\((\w+), (\w+)', line)
         if m:
             atype, aid = m.groups()
-            atype = atype.capitalize()
             atype = typetrans.get(atype.lower(), atype)
+            atype = 'Attribute.' + atype
             aname, adefault = attr_defaults.get(aid)
-            if adefault:
-                print '    this.addAttribute(cAttribute%s, "%s", "%s", %s);' % (atype, aid, aname, adefault)
-            else:
-                print '    this.addAttribute(cAttribute%s, "%s", "%s");' % (atype, aid, aname)
+            if adefault.startswith('AssetReference(""'):
+                adefault = '""'
+            #if adefault:
+            print attrtemplate % (aid, aidx, aid, adefault, atype, aname)
+            #"else:
+            #    print '    this.addAttribute(cAttribute%s, "%s", "%s");' % (atype, aid, aname)
+            aidx += 1
 
     print '}'
     print


### PR DESCRIPTION
doesn't output complete EC js now but just the attrdefs to copy-paste.

works enough to create this from the EC_Sound.h & .cpp now:

```
        /**
            @property soundRef (attribute)
            @type Attribute
        */
        this.declareAttribute(0, "soundRef", "", Attribute.AssetReference, "Sound ref");
        /**
            @property soundInnerRadius (attribute)
            @type Attribute
        */
        this.declareAttribute(1, "soundInnerRadius", 0.0, Attribute.Real, "Sound radius inner");
        /**
            @property soundOuterRadius (attribute)
            @type Attribute
        */
        this.declareAttribute(2, "soundOuterRadius", 20.0, Attribute.Real, "Sound radius outer");
        /**
            @property soundGain (attribute)
            @type Attribute
        */
        this.declareAttribute(3, "soundGain", 1.0, Attribute.Real, "Sound gain");
        /**
            @property playOnLoad (attribute)
            @type Attribute
        */
        this.declareAttribute(4, "playOnLoad", false, Attribute.Bool, "Play on load");
        /**
            @property loopSound (attribute)
            @type Attribute
        */
        this.declareAttribute(5, "loopSound", false, Attribute.Bool, "Loop sound");
        /**
            @property spatial (attribute)
            @type Attribute
        */
        this.declareAttribute(6, "spatial", true, Attribute.Bool, "Spatial");
 ```