### PR TITLE
restore registration of Three's asset types, removed (accidentally?) in the r71 update

### DIFF
--- a/examples/Physics/index.html
+++ b/examples/Physics/index.html
@@ -22,7 +22,7 @@
 <body>
 
 <!-- require.js entry point -->
-<script data-main="main.js" src="../../src/lib/require.min.js"></script>
+<script data-main="main.js" src="../../src/lib/require.js"></script>
 
 <!-- HTML -->
 <div id="webtundra-container-custom"></div>

--- a/examples/xml3d/example-suzanne.html
+++ b/examples/xml3d/example-suzanne.html
@@ -53,6 +53,6 @@
         </xml3d>
 
 <!-- require.js entry point -->
-<script data-main="loadxml3d.js" src="../../src/lib/require.min.js"></script>
+<script data-main="loadxml3d.js" src="../../src/lib/require.js"></script>
 </body>
 </html>

--- a/examples/xml3d/loadxml3d.js
+++ b/examples/xml3d/loadxml3d.js
@@ -58,7 +58,7 @@ require([
     });
 
     // Configure asset redirects.
-    var redirectPlugin = TundraSDK.plugin("AssetRedirectPlugin");
+    var redirectPlugin = Tundra.plugin("AssetRedirectPlugin");
     redirectPlugin.registerAssetTypeSwap(".mesh", ".json", "ThreeJsonMesh");
     redirectPlugin.setupDefaultStorage();
 
@@ -67,7 +67,7 @@ require([
 //    var instructions = null;
 
     // Start freecam app
-    $.getScript("../../src/application/freecamera.js")
+    $.getScript("../../src/application/freecamera.webtundrajs")
         .done(function( script, textStatus ) {
             freecamera = new FreeCameraApplication();
         })
@@ -104,7 +104,7 @@ require([
         client.renderer.scene.add(dirLight);
 //    });
 
-    var sceneParserPlugin = TundraSDK.plugin("SceneParserPlugin");
+    var sceneParserPlugin = Tundra.plugin("SceneParserPlugin");
     var xml3dParser = sceneParserPlugin.newXML3DParser(client.scene);
     $(document).ready(function() {
         xml3dParser.parseDocXml3D(document);

--- a/src/plugins/asset-redirect/AssetRedirectPlugin.js
+++ b/src/plugins/asset-redirect/AssetRedirectPlugin.js
@@ -1,11 +1,11 @@
 
 define([
-        "core/framework/TundraSDK",
+        "core/framework/Tundra",
         "core/framework/ITundraPlugin",
         "core/framework/CoreStringUtils",
         "core/asset/AssetAPI",
         "plugins/asset-redirect/RedirectResolver"
-    ], function(TundraSDK, ITundraPlugin, CoreStringUtils, AssetAPI, RedirectResolver) {
+    ], function(Tundra, ITundraPlugin, CoreStringUtils, AssetAPI, RedirectResolver) {
 
 /**
     This plugin provides a IHttpProxyResolver implementation that can be configured
@@ -194,7 +194,7 @@ var AssetRedirectPlugin = ITundraPlugin.$extend(
     }
 });
 
-TundraSDK.registerPlugin(new AssetRedirectPlugin());
+Tundra.registerPlugin(new AssetRedirectPlugin());
 
 return AssetRedirectPlugin;
 

--- a/src/plugins/asset-redirect/RedirectResolver.js
+++ b/src/plugins/asset-redirect/RedirectResolver.js
@@ -1,9 +1,9 @@
 
 define([
-        "core/framework/TundraSDK",
+        "core/framework/Tundra",
         "core/framework/CoreStringUtils",
         "core/asset/IHttpProxyResolver",
-    ], function(TundraSDK, CoreStringUtils, IHttpProxyResolver) {
+    ], function(Tundra, CoreStringUtils, IHttpProxyResolver) {
 
 /**
     @class RedirectResolver
@@ -15,7 +15,7 @@ var RedirectResolver = IHttpProxyResolver.$extend(
     __init__ : function()
     {
         this.$super("RedirectResolver");
-        this.framework = TundraSDK.framework;
+        this.framework = Tundra.framework;
 
         this.typeSwaps = {};
     },

--- a/src/plugins/scene-parser/SceneParser.js
+++ b/src/plugins/scene-parser/SceneParser.js
@@ -13,10 +13,10 @@
 
 define([
         "lib/classy",
-        "core/framework/TundraSDK",
+        "core/framework/Tundra",
         "core/framework/CoreStringUtils",
         "core/framework/TundraLogging"
-    ], function(Class, TundraSDK, CoreStringUtils, TundraLogging) {
+    ], function(Class, Tundra, CoreStringUtils, TundraLogging) {
 
 var SceneParser = Class.$extend(
 {
@@ -34,7 +34,7 @@ var SceneParser = Class.$extend(
     {
         this.log.debug("Fetching source", url);
 
-        var transfer = TundraSDK.framework.asset.requestAsset(url, "Text");
+        var transfer = Tundra.framework.asset.requestAsset(url, "Text");
         transfer.onCompleted(this, function(asset) {
             this.log.debug("Creating asset refs with base", asset.baseRef);
             this.baseRef = asset.baseRef;
@@ -48,23 +48,23 @@ var SceneParser = Class.$extend(
         xhttp.send(null);
         var doc = xhttp.responseXML;
         this.log.debug(typeof doc, xhttp);
-        TundraSDK.check(doc !== null);
+        Tundra.check(doc !== null);
         return this.parseDocXml3D(doc);*/
     },
 
     parseFromUrlXml3D : function(url)
     {
-        TundraSDK.checkDefined(url);
+        Tundra.checkDefined(url);
         var xhttp = new XMLHttpRequest();
         //xhttp.overrideMimeType('text/xml');
-        TundraSDK.check(typeof(url) === "string");
+        Tundra.check(typeof(url) === "string");
         this.log.debug("xhr start");
         xhttp.onreadystatechange = function() {
             console.log("xhr callback");
             if (xhttp.readyState == 4) {
                 if (xhttp.status == 200) {
                     var doc = xhttp.response;
-                    TundraSDK.check(doc !== null);               
+                    Tundra.check(doc !== null);
                     this.parseDocXml3D(doc);
                 }
             } else {
@@ -174,7 +174,7 @@ var SceneParser = Class.$extend(
 
         var setPlaceableFromGroupNode = function(placeable, groupNode)
         {
-            TundraSDK.check(!!groupNode);
+            Tundra.check(!!groupNode);
             var xTransform = groupNode.getAttribute("transform");
             if (!xTransform)
                 return false;
@@ -204,7 +204,7 @@ var SceneParser = Class.$extend(
 
             entity = this.createEntityWithPlaceable();
             this.log.debug("  Created Entity", entity.toString());
-            TundraSDK.check(!!entity.placeable);
+            Tundra.check(!!entity.placeable);
             var gotTransform = setPlaceableFromGroupNode(entity.placeable, group);
             if (!gotTransform)
                 this.log.debug("using default transform for group", group);
@@ -310,7 +310,7 @@ function getDirectChildNodesByTagName(node, tagName)
 function xyzAngleToQuaternion(nums)
 {
     /* formula from xml3d.js's rotation.js */
-    TundraSDK.check(nums.length === 4);
+    Tundra.check(nums.length === 4);
     var axisVec = new THREE.Vector3(nums[0], nums[1], nums[2]);
     var axisLength = axisVec.length();
     var quatXyzw;
@@ -333,7 +333,7 @@ function wtNodeListToArray(nodeList)
 {
     var out = [];
     out.push.apply(out, nodeList);
-    TundraSDK.check(out.length === nodeList.length);
+    Tundra.check(out.length === nodeList.length);
     return out;
 }
 
@@ -393,7 +393,7 @@ function wtFindTransformDefs(root)
             TundraLogging.getLogger("SceneParserUtils").debug("incomplete transform " + transformId + ":", trans, rot, scale);
         }
         TundraLogging.getLogger("SceneParserUtils").debug("transform: " + transformId);
-        TundraSDK.check(!!(trans || rot || scale));
+        Tundra.check(!!(trans || rot || scale));
         foundTransforms[transformId] = makeSetter(trans, rot, scale);
     }
     TundraLogging.getLogger("SceneParserUtils").debug("transform finding finished");
@@ -403,7 +403,7 @@ function wtFindTransformDefs(root)
 function wtSplitToXyz(s, v3)
 {
     var nums = s.split(/\s+/).map(parseFloat);
-    TundraSDK.check(nums.length === 3);
+    Tundra.check(nums.length === 3);
     v3.x = nums[0]; v3.y = nums[1]; v3.z = nums[2];
     // console.log("wtSplitToXyz: " + nums);
 }
@@ -412,7 +412,7 @@ function wtSplitAxisAngleToEulerXyz(s, xfrmRot)
 {
     var nums = s.split(/\s+/).map(parseFloat);
     var euler = new THREE.Euler();
-    TundraSDK.check(nums.length === 4);
+    Tundra.check(nums.length === 4);
     var q = xyzAngleToQuaternion(nums);
     euler.setFromQuaternion(q);
     /* ec convention is degrees */

--- a/src/plugins/scene-parser/SceneParserPlugin.js
+++ b/src/plugins/scene-parser/SceneParserPlugin.js
@@ -1,9 +1,9 @@
 
 define([
-        "core/framework/TundraSDK",
+        "core/framework/Tundra",
         "core/framework/ITundraPlugin",
         "plugins/scene-parser/SceneParser"
-    ], function(TundraSDK, ITundraPlugin, SceneParser) {
+    ], function(Tundra, ITundraPlugin, SceneParser) {
 
 var SceneParserPlugin = ITundraPlugin.$extend(
 {
@@ -18,7 +18,7 @@ var SceneParserPlugin = ITundraPlugin.$extend(
     }
 });
 
-TundraSDK.registerPlugin(new SceneParserPlugin());
+Tundra.registerPlugin(new SceneParserPlugin());
 
 return SceneParserPlugin;
 

--- a/src/view/threejs/ThreeJsRenderer.js
+++ b/src/view/threejs/ThreeJsRenderer.js
@@ -10,6 +10,9 @@ define([
         "core/renderer/IRenderSystem",
         "core/renderer/RaycastResult",
         "view/threejs/TransformInterpolator",
+        "core/asset/AssetFactory",
+        "view/threejs/asset/ObjMeshAsset",
+        "view/threejs/asset/ThreeJsonAsset",
         "view/threejs/entity-components/EC_Fog_ThreeJs",
         "view/threejs/entity-components/EC_Sky_ThreeJs",
         "view/threejs/entity-components/EC_SkyX_ThreeJs",
@@ -19,7 +22,9 @@ define([
         "view/threejs/entity-components/EC_Mesh_ThreeJs",
         "view/threejs/entity-components/EC_Placeable_ThreeJs"
     ], function(THREE, TWEEN, Tundra, TundraLogging, CoreStringUtils,
-                Scene, Color, IRenderSystem, RaycastResult, TransformInterpolator,
+                Scene, Color, IRenderSystem, RaycastResult, TransformInterpolator, AssetFactory,
+                ObjMeshAsset,
+                ThreeJsonAsset,
                 EC_Fog_ThreeJs,
                 EC_Sky_ThreeJs,
                 EC_SkyX_ThreeJs,
@@ -210,6 +215,9 @@ var ThreeJsRenderer = IRenderSystem.$extend(
         this.materialLoadError = new THREE.MeshPhongMaterial({ "color": this.convertColor("rgb(240,50,50)"), "wireframe" : false });
         this.materialLoadError.name = "tundra.MaterialLibrary.LoadError";
 
+        // Register the three.js asset and component implementations
+        this.registerAssetFactories();
+
         // Register the three.js implementations of Tundra components
         this.registerComponents();
     },
@@ -323,6 +331,15 @@ var ThreeJsRenderer = IRenderSystem.$extend(
         for (var key in this._sceneObjects)
             list = list.concat(this._sceneObjects[key]);
         return list;
+    },
+
+    registerAssetFactories : function()
+    {
+        /** @note It would be too wide of acceptance range if the three.js json accepted all .json file extensions.
+         * .3geo is a three.js "standardized" extensions for mesh assets, but not widely used (yet).
+         * You can load from .json/.js files via AssetAPI but you need to force the type to "ThreeJsonMesh". */
+        Tundra.framework.asset.registerAssetFactory(new AssetFactory("ThreeJsonMesh", ThreeJsonAsset, { ".3geo" : "json", ".json" : "json", ".js" : "json" }, "json"));
+        Tundra.framework.asset.registerAssetFactory(new AssetFactory("ObjMesh", ObjMeshAsset, { ".obj" : "text" }));
     },
 
     registerComponents : function()

--- a/src/view/threejs/asset/ObjMeshAsset.js
+++ b/src/view/threejs/asset/ObjMeshAsset.js
@@ -2,9 +2,9 @@
 define([
         "lib/three",
         "lib/three/OBJLoader",
-        "core/framework/TundraSDK",
+        "core/framework/Tundra",
         "core/asset/IAsset"
-    ], function(THREE, OBJLoader, TundraSDK, IAsset) {
+    ], function(THREE, OBJLoader, Tundra, IAsset) {
 
 /**
     Represents a OBJ mesh asset. This asset is processed and Three.js rendering engine meshes are generated.
@@ -82,7 +82,7 @@ var ObjMeshAsset = IAsset.$extend(
         /// @todo This is probaly very slow. Figure out a faster way to do this.
         /// We could do internal bookkeeping on how many with this UUID have been created.
         var used = false;
-        TundraSDK.framework.renderer.scene.traverse(function(node) {
+        Tundra.framework.renderer.scene.traverse(function(node) {
             // We are only interested in things that are using a geometry.
             if (used === true || node == null || node.geometry === undefined ||
                 (!(node.geometry instanceof THREE.BufferGeometry) && !(node.geometry instanceof THREE.Geometry)))
@@ -102,16 +102,16 @@ var ObjMeshAsset = IAsset.$extend(
         // is safe to unload.
 
         var meshAsset = new ObjMeshAsset(newAssetName);
-        meshAsset.mesh = TundraSDK.framework.renderer.createSceneNode();
+        meshAsset.mesh = Tundra.framework.renderer.createSceneNode();
         for (var i=0, len=this.numSubmeshes(); i<len; ++i)
         {
             var existingSubmesh = this.getSubmesh(i);
             var clonedSubmesh = null;
 
             if (existingSubmesh instanceof THREE.SkinnedMesh)
-                clonedSubmesh = new THREE.SkinnedMesh(existingSubmesh.geometry, TundraSDK.framework.renderer.materialWhite, false);
+                clonedSubmesh = new THREE.SkinnedMesh(existingSubmesh.geometry, Tundra.framework.renderer.materialWhite, false);
             else
-                clonedSubmesh = new THREE.Mesh(existingSubmesh.geometry, TundraSDK.framework.renderer.materialWhite);
+                clonedSubmesh = new THREE.Mesh(existingSubmesh.geometry, Tundra.framework.renderer.materialWhite);
 
             clonedSubmesh.name = meshAsset.name + "_submesh_" + i;
             clonedSubmesh.tundraSubmeshIndex = existingSubmesh.tundraSubmeshIndex;
@@ -144,7 +144,7 @@ var ObjMeshAsset = IAsset.$extend(
         }
 
         if (this.mesh === undefined || this.mesh === null)
-            this.mesh = TundraSDK.framework.renderer.createSceneNode();
+            this.mesh = Tundra.framework.renderer.createSceneNode();
 
         // Placeable will update the matrix when changes occur.
         this.mesh.name = this.name;

--- a/src/view/threejs/asset/ThreeJsonAsset.js
+++ b/src/view/threejs/asset/ThreeJsonAsset.js
@@ -1,9 +1,9 @@
 
 define([
         "lib/three",
-        "core/framework/TundraSDK",
+        "core/framework/Tundra",
         "core/asset/IAsset"
-    ], function(THREE, TundraSDK, IAsset) {
+    ], function(THREE, Tundra, IAsset) {
 
 /**
     Represents a three.js json mesh asset. The input data is processed and Three.js rendering engine meshes are generated.
@@ -81,7 +81,7 @@ var ThreeJsonAsset = IAsset.$extend(
         /// @todo This is probaly very slow. Figure out a faster way to do this.
         /// We could do internal bookkeeping on how many with this UUID have been created.
         var used = false;
-        TundraSDK.framework.renderer.scene.traverse(function(node) {
+        Tundra.framework.renderer.scene.traverse(function(node) {
             // We are only interested in things that are using a geometry.
             if (used === true || node == null || node.geometry === undefined ||
                 (!(node.geometry instanceof THREE.BufferGeometry) && !(node.geometry instanceof THREE.Geometry)))
@@ -101,16 +101,16 @@ var ThreeJsonAsset = IAsset.$extend(
         // is safe to unload.
 
         var meshAsset = new ThreeJsonAsset(newAssetName);
-        meshAsset.mesh = TundraSDK.framework.renderer.createSceneNode();
+        meshAsset.mesh = Tundra.framework.renderer.createSceneNode();
         for (var i=0, len=this.numSubmeshes(); i<len; ++i)
         {
             var existingSubmesh = this.getSubmesh(i);
             var clonedSubmesh = null;
 
             if (existingSubmesh instanceof THREE.SkinnedMesh)
-                clonedSubmesh = new THREE.SkinnedMesh(existingSubmesh.geometry, TundraSDK.framework.renderer.materialWhite, false);
+                clonedSubmesh = new THREE.SkinnedMesh(existingSubmesh.geometry, Tundra.framework.renderer.materialWhite, false);
             else
-                clonedSubmesh = new THREE.Mesh(existingSubmesh.geometry, TundraSDK.framework.renderer.materialWhite);
+                clonedSubmesh = new THREE.Mesh(existingSubmesh.geometry, Tundra.framework.renderer.materialWhite);
 
             clonedSubmesh.name = meshAsset.name + "_submesh_" + i;
             clonedSubmesh.tundraSubmeshIndex = existingSubmesh.tundraSubmeshIndex;
@@ -143,7 +143,7 @@ var ThreeJsonAsset = IAsset.$extend(
                 if (threejsData.materials !== undefined)
                     material = (threejsData.materials.length === 1 ? threejsData.materials[0] : new THREE.MeshFaceMaterial(threejsData.materials));
 
-                this.mesh = TundraSDK.framework.renderer.createSceneNode();
+                this.mesh = Tundra.framework.renderer.createSceneNode();
                 this.mesh.add(new THREE.Mesh(threejsData.geometry, material));
             }
             else
@@ -156,7 +156,7 @@ var ThreeJsonAsset = IAsset.$extend(
         }
 
         if (this.mesh === undefined || this.mesh === null)
-            this.mesh = TundraSDK.framework.renderer.createSceneNode();
+            this.mesh = Tundra.framework.renderer.createSceneNode();
 
         // Placeable will update the matrix when changes occur.
         this.mesh.name = this.name;


### PR DESCRIPTION
this is the commit by @cvetan5 which removed these registrations:
https://github.com/realXtend/WebTundra/commit/b5429139f4dd405ab27fabb77993e05983b7bf72#diff-2ad1c289180972affa7a4c238382a478

also: fix examples, client-side scene parser and asset impls too after TundraSDK -> Tundra change.

now the minimal suzanne example works except for freecam that doesn't seem to work anywhere now?